### PR TITLE
Introduce with_playwright_page and with_playwright_element_handle

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,16 @@ Capybara.save_path = 'tmp/capybara'
 Capybara.app_host = 'https://github.com'
 visit '/'
 fill_in('q', with: 'Capybara')
-find('a[data-item-type="global_search"]').click
+
+## [REMARK] Use Playwright-native Page instead of flaky Capybara's selector/action.
+# find('a[data-item-type="global_search"]').click
+page.driver.with_playwright_page do |page|
+  page.click('a[data-item-type="global_search"]')
+end
+
 all('.repo-list-item').each do |li|
-  puts li.all('a').first.text
+  puts "#{li.all('a').first.text} by Capybara"
+  puts "#{li.with_playwright_element_handle { |handle| handle.query_selector('a').text_content }} by Playwright"
 end
 ```
 

--- a/lib/capybara/playwright/browser.rb
+++ b/lib/capybara/playwright/browser.rb
@@ -132,6 +132,12 @@ module Capybara
           arg
         end
       end
+
+      def with_playwright_page(&block)
+        raise ArgumentError.new('block must be given') unless block
+
+        block.call(@playwright_page)
+      end
     end
   end
 end

--- a/lib/capybara/playwright/driver.rb
+++ b/lib/capybara/playwright/driver.rb
@@ -89,6 +89,9 @@ module Capybara
       def_delegator(:browser, :no_such_window_error)
       def_delegator(:browser, :accept_modal)
       def_delegator(:browser, :dismiss_modal)
+
+      # capybara-playwright-driver specific methods
+      def_delegator(:browser, :with_playwright_page)
     end
   end
 end

--- a/spec/feature/example_spec.rb
+++ b/spec/feature/example_spec.rb
@@ -18,10 +18,16 @@ RSpec.describe 'Example' do
     Capybara.app_host = 'https://github.com'
     visit '/'
     fill_in('q', with: 'Capybara')
-    sleep 1
-    find('a[data-item-type="global_search"]').click
+
+    ## [REMARK] Use Playwright-native Page instead of flaky Capybara's selector/action.
+    # find('a[data-item-type="global_search"]').click
+    page.driver.with_playwright_page do |page|
+      page.click('a[data-item-type="global_search"]')
+    end
+
     all('.repo-list-item').each do |li|
-      puts li.all('a').first.text
+      puts "#{li.all('a').first.text} by Capybara"
+      puts "#{li.with_playwright_element_handle { |handle| handle.query_selector('a').text_content }} by Playwright"
     end
   end
 end


### PR DESCRIPTION
```
find('a[data-item-type="global_search"]').click
```

Capybara's selector and action (click, select_option, ...) is very flaky.
Because the finder selects nodes with `query_selector_all` and check the visibility with `visible?` **by polling with a bit sleep**.
Playwright introduces very relyable [auto-waiting feature](https://playwright.dev/docs/actionability/). We should use it instead of polling and sleep.

This PR adds 2 methods for exposing native playwright Page/ElementHandle instance
