### PR TITLE
Fix current_url, title to return page info

### DIFF
--- a/lib/capybara/playwright/browser.rb
+++ b/lib/capybara/playwright/browser.rb
@@ -48,7 +48,7 @@ module Capybara
       def current_url
         assert_page_alive
 
-        @playwright_page.capybara_current_frame.url
+        @playwright_page.url
       end
 
       def visit(path)
@@ -117,7 +117,7 @@ module Capybara
       def title
         assert_page_alive
 
-        @playwright_page.capybara_current_frame.title
+        @playwright_page.title
       end
 
       def go_back

--- a/spec/capybara/playwright_spec.rb
+++ b/spec/capybara/playwright_spec.rb
@@ -35,6 +35,9 @@ Capybara::SpecHelper.run_specs TestSessions::Playwright, 'Playwright', capybara_
 
   includes = [ # https://github.com/teamcapybara/capybara/tree/master/lib/capybara/spec/session
     'node_spec.rb',
+    'current_url_spec.rb',
+    'title_spec.rb',
+    'visit_spec.rb',
     'evaluate_async_script_spec.rb',
     'scroll_spec.rb',
     'fill_in_spec.rb',


### PR DESCRIPTION
title and current_url should always return the information of Page even if within a frame.