### PR TITLE
fix CI failure without reset! called

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       - run:
           name: Setup playwright driver
           command: |
-            npm install playwright@next
+            npm install playwright
             ./node_modules/.bin/playwright install
       - run:
           name: RSpec

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: microsoft/playwright-github-action@v1
       - name: setup playwright via npm install
         run: |
-          npm install playwright@next
+          npm install playwright
           ./node_modules/.bin/playwright install
       - run: bundle exec rspec spec/feature/
         env:


### PR DESCRIPTION
It seems Playwright 1.12 have breaking changes around `page.on("response")`
Keep using Playwright 1.11 at this point.