### PR TITLE
Increase stability on click

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ Capybara.app_host = 'https://github.com'
 visit '/'
 fill_in('q', with: 'Capybara')
 
-## [REMARK] Use Playwright-native Page instead of flaky Capybara's selector/action.
+## [REMARK] We can use Playwright-native selector and action, instead of Capybara DSL.
 # find('a[data-item-type="global_search"]').click
 page.driver.with_playwright_page do |page|
   page.click('a[data-item-type="global_search"]')
 end
 
 all('.repo-list-item').each do |li|
-  puts "#{li.all('a').first.text} by Capybara"
+  #puts "#{li.all('a').first.text} by Capybara"
   puts "#{li.with_playwright_element_handle { |handle| handle.query_selector('a').text_content }} by Playwright"
 end
 ```

--- a/lib/capybara/playwright/node.rb
+++ b/lib/capybara/playwright/node.rb
@@ -696,6 +696,8 @@ module Capybara
       end
 
       def visible?
+        assert_element_not_stale
+
         # if an area element, check visibility of relevant image
         @element.evaluate(<<~JAVASCRIPT)
         function(el) {
@@ -732,10 +734,14 @@ module Capybara
       end
 
       def checked?
+        assert_element_not_stale
+
         @element.evaluate('el => !!el.checked')
       end
 
       def selected?
+        assert_element_not_stale
+
         @element.evaluate('el => !!el.selected')
       end
 

--- a/spec/feature/example_spec.rb
+++ b/spec/feature/example_spec.rb
@@ -40,14 +40,23 @@ RSpec.describe 'Example' do
     visit '/'
     fill_in('q', with: 'Capybara')
 
-    ## [REMARK] Use Playwright-native Page instead of flaky Capybara's selector/action.
-    # find('a[data-item-type="global_search"]').click
+    find('a[data-item-type="global_search"]').click
+
+    all('.repo-list-item').each do |li|
+      puts "#{li.all('a').first.text} by Capybara"
+    end
+  end
+
+  it 'search capybara using Playwright-native selector and action' do
+    Capybara.app_host = 'https://github.com'
+    visit '/'
+    fill_in('q', with: 'Capybara')
+
     page.driver.with_playwright_page do |page|
       page.click('a[data-item-type="global_search"]')
     end
 
     all('.repo-list-item').each do |li|
-      puts "#{li.all('a').first.text} by Capybara"
       puts "#{li.with_playwright_element_handle { |handle| handle.query_selector('a').text_content }} by Playwright"
     end
   end


### PR DESCRIPTION
Capybara checks `visible?` before clicing the node.

Current implementation checks visibility without checking it the element is attached or not. Thus, it causes error:

```
Failures:

  1) Example search capybara
     Failure/Error: @element.click(**click_options.as_params)
     
     Playwright::Error:
       Error: Element is not attached to the DOM
       =========================== logs ===========================
       attempting click action
         waiting for element to be visible, enabled and stable
         element is visible, enabled and stable
       ============================================================
       Note: use DEBUG=pw:api environment variable to capture Playwright logs.
     # ./lib/capybara/playwright/node.rb:345:in `click'
```

