### PR TITLE
Implement Node#drag_to

### DIFF
--- a/lib/capybara/playwright/browser.rb
+++ b/lib/capybara/playwright/browser.rb
@@ -69,7 +69,7 @@ module Capybara
         assert_page_alive
 
         @playwright_page.capybara_current_frame.query_selector_all("xpath=#{query}").map do |el|
-          Node.new(@driver, @puppeteer_page, el)
+          Node.new(@driver, @playwright_page, el)
         end
       end
 
@@ -300,7 +300,7 @@ module Capybara
             [key, wrap_node(value)]
           end.to_h
         when ::Playwright::ElementHandle
-          Node.new(@driver, @puppeteer_page, arg)
+          Node.new(@driver, @playwright_page, arg)
         when ::Playwright::JSHandle
           arg.json_value
         else

--- a/spec/capybara/playwright_spec.rb
+++ b/spec/capybara/playwright_spec.rb
@@ -17,9 +17,10 @@ Capybara::SpecHelper.run_specs TestSessions::Playwright, 'Playwright' do |exampl
     pending 'evaluateHandle does not work with Array.'
   when /when details is toggled open and closed/
     pending "NoMethodError: undefined method `and' for #<Capybara::RSpecMatchers::Matchers::HaveSelector:0x00007f9bafd56900>"
-  when /Playwright node #drag_to/,
-       /Element#drop/
+  when /Element#drop/
     pending 'not implemented'
+  when /drag_to.*HTML5/
+    skip 'not supported yet in Playwright driver'
   when /Playwright Capybara::Window#maximize/,
        /Playwright Capybara::Window#fullscreen/
     skip 'not supported in Playwright driver'


### PR DESCRIPTION
Just triggering mouse events.
HTML5 drag (dragstart, dragleave, dragend, etc) is still not supported... waiting https://github.com/microsoft/playwright/pull/6207 to be merged.