### PR TITLE
Reuse browser instance on reset_sessions!

### DIFF
--- a/lib/capybara/playwright/browser.rb
+++ b/lib/capybara/playwright/browser.rb
@@ -34,6 +34,11 @@ module Capybara
         end
       end
 
+      def reset!
+        @playwright_browser.contexts.each(&:close)
+        @playwright_page = create_page(create_browser_context)
+      end
+
       def quit
         @playwright_browser.close
       end

--- a/lib/capybara/playwright/driver.rb
+++ b/lib/capybara/playwright/driver.rb
@@ -6,6 +6,7 @@ module Capybara
       def initialize(app, **options)
         @playwright_cli_executable_path = options[:playwright_cli_executable_path] || 'npx playwright'
         @browser_type = options[:browser_type] || :chromium
+        @dispose_browser_on_reset = options[:dispose_browser_on_reset]
         unless %i(chromium firefox webkit).include?(@browser_type)
           raise ArgumentError.new("Unknown browser_type: #{@browser_type}")
         end
@@ -50,8 +51,12 @@ module Capybara
       end
 
       def reset!
-        quit
-        @browser = nil
+        if @dispose_browser_on_reset
+          quit
+          @browser = nil
+        else
+          @browser.reset!
+        end
       end
 
       def invalid_element_errors


### PR DESCRIPTION
Existing Capybara drivers don't dispose a browser instance on reset.

* selenium: https://github.com/teamcapybara/capybara/blob/master/lib/capybara/selenium/driver.rb#L159
* cuprite: https://github.com/rubycdp/cuprite/blob/master/lib/capybara/cuprite/driver.rb#L152
* apparition: https://github.com/twalpole/apparition/blob/master/lib/capybara/apparition/driver.rb#L144

Currently capybara-playwright-driver disposes Browser for every test case. It is terriblly slow.
