### PR TITLE
Fix evaluate_script to unwrap JS Array and object

### DIFF
--- a/lib/capybara/playwright/browser.rb
+++ b/lib/capybara/playwright/browser.rb
@@ -331,7 +331,11 @@ module Capybara
           obj_type, is_array = arg.evaluate('obj => [typeof obj, Array.isArray(obj)]')
           if obj_type == 'object'
             if is_array
-              arg.properties.map do |_, value|
+              # Firefox often include 'toJSON' into properties.
+              # https://github.com/microsoft/playwright/issues/7015
+              #
+              # Get rid of non-numeric entries.
+              arg.properties.select { |key, _| key.to_i.to_s == key.to_s }.map  do |_, value|
                 wrap_node(value)
               end
             else

--- a/lib/capybara/playwright/browser.rb
+++ b/lib/capybara/playwright/browser.rb
@@ -328,7 +328,20 @@ module Capybara
         when ::Playwright::ElementHandle
           Node.new(@driver, @playwright_page, arg)
         when ::Playwright::JSHandle
-          arg.json_value
+          obj_type, is_array = arg.evaluate('obj => [typeof obj, Array.isArray(obj)]')
+          if obj_type == 'object'
+            if is_array
+              arg.properties.map do |_, value|
+                wrap_node(value)
+              end
+            else
+              arg.properties.map do |key, value|
+                [key, wrap_node(value)]
+              end.to_h
+            end
+          else
+            arg.json_value
+          end
         else
           arg
         end

--- a/spec/capybara/playwright_spec.rb
+++ b/spec/capybara/playwright_spec.rb
@@ -13,8 +13,6 @@ Capybara::SpecHelper.run_specs TestSessions::Playwright, 'Playwright' do |exampl
     pending 'Playwright does not allow to click outside the element'
   when /should not retry clicking when wait is disabled/
     pending 'wait = 0 is not supported'
-  when /should support multiple statements via IIFE/
-    pending 'evaluateHandle does not work with Array.'
   when /when details is toggled open and closed/
     pending "NoMethodError: undefined method `and' for #<Capybara::RSpecMatchers::Matchers::HaveSelector:0x00007f9bafd56900>"
   when /Element#drop/


### PR DESCRIPTION
```
      node = @session.find(:css, '#change') # ensure page has loaded and element is available
      res = node.evaluate_script(<<~JS, 3)
        (function(n){
          var el = this;
          return [el, n];
        }).apply(this, arguments)
      JS
      expect(res).to eq [node, 3]
```

Fix impl to convert the node to Capybara::Node::Element.