### PR TITLE
Add options to execute Playwright.connect_to_playwright_server

### DIFF
--- a/capybara-playwright.gemspec
+++ b/capybara-playwright.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.4'
   spec.add_dependency 'capybara'
-  spec.add_dependency 'playwright-ruby-client', '>= 0.6.2'
+  spec.add_dependency 'playwright-ruby-client', '>= 0.8.0'
   spec.add_development_dependency 'allure-rspec'
   spec.add_development_dependency 'bundler', '~> 2.2.3'
   spec.add_development_dependency 'launchy', '>= 2.0.4'

--- a/lib/capybara/playwright.rb
+++ b/lib/capybara/playwright.rb
@@ -4,6 +4,7 @@ require 'capybara'
 require 'playwright'
 
 require 'capybara/playwright/browser'
+require 'capybara/playwright/browser_runner'
 require 'capybara/playwright/browser_options'
 require 'capybara/playwright/dialog_event_handler'
 require 'capybara/playwright/driver'

--- a/lib/capybara/playwright/browser_runner.rb
+++ b/lib/capybara/playwright/browser_runner.rb
@@ -1,0 +1,99 @@
+module Capybara
+    module Playwright
+      # playwright-ruby-client provides 3 methods to launch/connect browser.
+      #
+      # Playwright.create do |playwright|
+      #   playwright.chromium.launch do |browser|
+      #
+      # Playwright.connect_to_playwright_server do |playwright| ...
+      #   playwright.chromium.launch do |browser|
+      #
+      # Playwright.connect_to_browser_server do |browser| ...
+      #
+      # This class provides start/stop methods for driver.
+      # This is responsible for
+      # - managing PlaywrightExecution
+      # - launching browser with given option if needed
+      class BrowserRunner
+        class PlaywrightConnectToPlaywrightServer
+          def initialize(endpoint_url, options)
+            @ws_endpoint = endpoint_url
+            @browser_type = options[:browser_type] || :chromium
+            unless %i(chromium firefox webkit).include?(@browser_type)
+              raise ArgumentError.new("Unknown browser_type: #{@browser_type}")
+            end
+            @browser_options = BrowserOptions.new(options)
+          end
+
+          def playwright_execution
+            @playwright_execution ||= ::Playwright.connect_to_playwright_server(@ws_endpoint)
+          end
+
+          def playwright_browser
+            browser_type = playwright_execution.playwright.send(@browser_type)
+            browser_options = @browser_options.value
+            browser_type.launch(**browser_options)
+          end
+        end
+
+        class PlaywrightConnectToBrowserServer
+          def initialize(endpoint_url)
+            @ws_endpoint = endpoint_url
+          end
+
+          def playwright_execution
+            @playwright_execution ||= ::Playwright.connect_to_browser_server(@ws_endpoint)
+          end
+
+          def playwright_browser
+            playwright_execution.browser
+          end
+        end
+
+        class PlaywrightCreate
+          def initialize(options)
+            @playwright_cli_executable_path = options[:playwright_cli_executable_path] || 'npx playwright'
+            @browser_type = options[:browser_type] || :chromium
+            unless %i(chromium firefox webkit).include?(@browser_type)
+              raise ArgumentError.new("Unknown browser_type: #{@browser_type}")
+            end
+            @browser_options = BrowserOptions.new(options)
+          end
+
+          def playwright_execution
+            @playwright_execution ||= ::Playwright.create(
+              playwright_cli_executable_path: @playwright_cli_executable_path,
+            )
+          end
+
+          def playwright_browser
+            browser_type = playwright_execution.playwright.send(@browser_type)
+            browser_options = @browser_options.value
+            browser_type.launch(**browser_options)
+          end
+        end
+
+        def initialize(options)
+          @runner =
+            if options[:playwright_server_endpoint_url]
+              PlaywrightConnectToPlaywrightServer.new(options[:playwright_server_endpoint_url], options)
+            elsif options[:browser_server_endpoint_url]
+              PlaywrightConnectToBrowserServer.new(options[:browser_server_endpoint_url])
+            else
+              PlaywrightCreate.new(options)
+            end
+        end
+
+        # @return [::Playwright::Browser]
+        def start
+          @playwright_execution = @runner.playwright_execution
+          @runner.playwright_browser
+        end
+
+        def stop
+          @playwright_execution&.stop
+          @playwright_execution = nil
+        end
+      end
+    end
+  end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,8 @@ end
 
 Capybara.register_driver(:playwright) do |app|
   Capybara::Playwright::Driver.new(app,
+    browser_server_endpoint_url: ENV['BROWSER_SERVER_ENDPOINT_URL'],
+    playwright_server_endpoint_url: ENV['PLAYWRIGHT_SERVER_ENDPOINT_URL'],
     playwright_cli_executable_path: ENV['PLAYWRIGHT_CLI_EXECUTABLE_PATH'],
     browser_type: (ENV['BROWSER'] || 'chromium').to_sym,
     headless: ENV['CI'] ? true : false,


### PR DESCRIPTION
resolves #43 
Playwright allows three methods for launching browser. This PR make it possible to run connect_to_playwright_server and connect_to_browser_server.

* **Playwright.create** (already available)
* **Playwright.connect_to_playwright_server** https://github.com/YusukeIwaki/playwright-ruby-client/pull/123 (requires playwright-ruby-client >= 0.8.0 and websocket-driver)
* **Playwright.connect_to_browser_server** https://github.com/YusukeIwaki/playwright-ruby-client/pull/155 (requires playwright-ruby-client >= 1.1.5.beta1 and websocket-driver)

---

connect_to_browser_server is tested, however shipped only as a beta release at this moment.
So this PR changes the minimum version of playwright-ruby-client to **0.8.0**.