### PR TITLE
Add serviceWorkers to PageOptions

### DIFF
--- a/lib/capybara/playwright/page_options.rb
+++ b/lib/capybara/playwright/page_options.rb
@@ -27,6 +27,7 @@ module Capybara
         record_video_dir: nil,
         record_video_size: nil,
         screen: nil,
+        serviceWorkers: nil,
         storageState: nil,
         timezoneId: nil,
         userAgent: nil,


### PR DESCRIPTION
Allow serviceWorkers option as a valid new_context option.
https://playwright-ruby-client.vercel.app/docs/api/browser#new_context