### PR TITLE
Allow for setting Playwright's default time out

### DIFF
--- a/lib/capybara/playwright/browser.rb
+++ b/lib/capybara/playwright/browser.rb
@@ -14,19 +14,21 @@ module Capybara
 
       class NoSuchWindowError < StandardError ; end
 
-      def initialize(driver:, playwright_browser:, page_options:, record_video: false, default_navigation_timeout: nil)
+      def initialize(driver:, playwright_browser:, page_options:, record_video: false, default_timeout: nil, default_navigation_timeout: nil)
         @driver = driver
         @playwright_browser = playwright_browser
         @page_options = page_options
         if record_video
           @page_options[:record_video_dir] ||= tmpdir
         end
+        @default_timeout = default_timeout
         @default_navigation_timeout = default_navigation_timeout
         @playwright_page = create_page(create_browser_context)
       end
 
       private def create_browser_context
         @playwright_browser.new_context(**@page_options).tap do |browser_context|
+          browser_context.default_timeout = @default_timeout if @default_timeout
           browser_context.default_navigation_timeout = @default_navigation_timeout if @default_navigation_timeout
           browser_context.on('page', ->(page) {
             unless @playwright_page

--- a/lib/capybara/playwright/driver.rb
+++ b/lib/capybara/playwright/driver.rb
@@ -10,7 +10,10 @@ module Capybara
         @browser_runner = BrowserRunner.new(options)
         @page_options = PageOptions.new(options)
         if options[:timeout].is_a?(Numeric)
-          @default_navigation_timeout = options[:timeout] * 1000
+          timeout = options[:timeout] * 1000
+
+          @default_timeout = timeout
+          @default_navigation_timeout = timeout
         end
       end
 
@@ -23,6 +26,7 @@ module Capybara
           playwright_browser: playwright_browser,
           page_options: @page_options.value,
           record_video: callback_on_save_screenrecord?,
+          default_timeout: @default_timeout,
           default_navigation_timeout: @default_navigation_timeout,
         )
       end

--- a/lib/capybara/playwright/driver.rb
+++ b/lib/capybara/playwright/driver.rb
@@ -9,11 +9,14 @@ module Capybara
       def initialize(app, **options)
         @browser_runner = BrowserRunner.new(options)
         @page_options = PageOptions.new(options)
-        if options[:timeout].is_a?(Numeric)
-          timeout = options[:timeout] * 1000
-
-          @default_timeout = timeout
-          @default_navigation_timeout = timeout
+        if options[:timeout].is_a?(Numeric) # just for compatibility with capybara-selenium-driver
+          @default_navigation_timeout = options[:timeout] * 1000
+        end
+        if options[:default_timeout].is_a?(Numeric)
+          @default_timeout = options[:default_timeout] * 1000
+        end
+        if options[:default_navigation_timeout].is_a?(Numeric)
+          @default_navigation_timeout = options[:default_navigation_timeout] * 1000
         end
       end
 

--- a/spec/feature/timeout_spec.rb
+++ b/spec/feature/timeout_spec.rb
@@ -34,4 +34,12 @@ RSpec.describe 'timeout', sinatra: true do
     end
     expect { visit '/sleep?s=3' }.to raise_error(Playwright::TimeoutError)
   end
+
+  it "respects the custom default time out", driver: :playwright_timeout_2 do
+    visit "/sleep?s=0"
+
+    expect {
+      page.driver.with_playwright_page(&:itself).get_by_label('does not exist').text_content
+    }.to raise_error(Playwright::TimeoutError, /Timeout 2000ms exceeded/)
+  end
 end


### PR DESCRIPTION
I noticed that  the `default_timeout` is not customizable while the `default_navigation_timeout ` is. It is probably not common to use `get_by_label` in Ruby, but it does have a use case (e.g. grabbing an input in a shadow root) and it may be more popular as people start utilizing new web APIs. The default 30s timeout is very long and I would like this to be customizable as well.