### PR TITLE
Add helper methods for starting/stopping trace

### DIFF
--- a/lib/capybara/playwright/driver_extension.rb
+++ b/lib/capybara/playwright/driver_extension.rb
@@ -40,6 +40,33 @@ module Capybara
 
         @browser&.with_playwright_page(&block)
       end
+
+      # Start Playwright tracing (doc: https://playwright.dev/docs/api/class-tracing#tracing-start)
+      def start_tracing(name: nil, screenshots: false, snapshots: false, sources: false, title: nil)
+        # Ensure playwright page is initialized.
+        browser
+
+        with_playwright_page do |playwright_page|
+          playwright_page.context.tracing.start(name: name, screenshots: screenshots, snapshots: snapshots, sources: sources, title: title)
+        end
+      end
+
+      # Stop Playwright tracing (doc: https://playwright.dev/docs/api/class-tracing#tracing-stop)
+      def stop_tracing(path: nil)
+        with_playwright_page do |playwright_page|
+          playwright_page.context.tracing.stop(path: path)
+        end
+      end
+
+      # Trace execution of the given block. The tracing is automatically stopped when the block is finished.
+      def trace(name: nil, screenshots: false, snapshots: false, sources: false, title: nil, path: nil, &block)
+        raise ArgumentError.new('block must be given') unless block
+
+        start_tracing(name: name, screenshots: screenshots, snapshots: snapshots, sources: sources, title: title)
+        block.call
+      ensure
+        stop_tracing(path: path)
+      end
     end
   end
 end

--- a/spec/feature/tracing_spec.rb
+++ b/spec/feature/tracing_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+RSpec.describe 'tracing', sinatra: true do
+  TRACES_DIR = 'tmp/capybara/playwright'.freeze
+
+  before do
+    FileUtils.rm_rf(TRACES_DIR)
+
+    sinatra.get '/' do
+      <<~HTML
+        <!DOCTYPE html>
+        <button>Go</button>
+      HTML
+    end
+  end
+
+  it 'can start and stop tracing' do
+    page.driver.start_tracing(name: "test_trace", screenshots: true, snapshots: true, sources: true, title: "test_trace")
+
+    visit '/'
+    click_on 'Go'
+    expect(page).to have_content('Go')
+
+    page.driver.stop_tracing(path: "#{TRACES_DIR}/test_trace.zip")
+
+    expect(File).to exist("#{TRACES_DIR}/test_trace.zip")
+  end
+
+  it 'can enable tracing only in the block' do
+    page.driver.trace name: "test_trace_with_block", screenshots: true, snapshots: true, sources: true, title: "title", path: "#{TRACES_DIR}/test_trace_with_block.zip" do
+      visit '/'
+      click_on 'Go'
+      expect(page).to have_content('Go')
+    end
+
+    expect(File).to exist("#{TRACES_DIR}/test_trace_with_block.zip")
+  end
+
+  it 'does not start tracing when no block is given' do
+    expect { page.driver.trace }.to raise_error(ArgumentError)
+
+    expect {
+      page.driver.start_tracing
+      page.driver.stop_tracing
+    }.not_to raise_error(Playwright::Error, /Tracing has been already started/)
+  end
+end


### PR DESCRIPTION
Given the issue #65, it seems like there is some general interest in a simpler interface for using traces. The code in this PR is the code I use to test https://toprubycompanies.info in CI, and it's been working very well.

With the new interfaces introduced by this PR, using Playwright's trace is as simple as:

```ruby
class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
  driven_by :playwright

  setup do
    page.driver.start_tracing(title: method_name) if retrying?
  end

  def before_teardown
    if retrying?
      page.driver.stop_tracing(path: "./tmp/playwright/traces/#{method_name}.zip"))
    end
  ensure
    super
  end

  def retrying?
    # Determine whether the run is a retry...
  end
end
```

With RSpec, it could look like:

```ruby
around :example do |example|
  if should_trace?
    page.driver.trace path: "./tmp/playwright/traces/#{example.metadata[:full_description]}.zip" do
      example.run
    end
  end
end

def should_trace?
  # Somehow determine whether the run should be traced.
end
```