### PR TITLE
Provide a simple configuration for tracing

### DIFF
--- a/lib/capybara/playwright/driver.rb
+++ b/lib/capybara/playwright/driver.rb
@@ -29,6 +29,7 @@ module Capybara
           playwright_browser: playwright_browser,
           page_options: @page_options.value,
           record_video: callback_on_save_screenrecord?,
+          callback_on_save_trace: @callback_on_save_trace,
           default_timeout: @default_timeout,
           default_navigation_timeout: @default_navigation_timeout,
         )

--- a/lib/capybara/playwright/driver_extension.rb
+++ b/lib/capybara/playwright/driver_extension.rb
@@ -35,6 +35,14 @@ module Capybara
         @callback_on_save_screenrecord&.call(video_path)
       end
 
+      # Register trace save process.
+      # The callback is called just after trace is saved.
+      #
+      # The trace.zip path (String) is called back into the given block
+      def on_save_trace(&block)
+        @callback_on_save_trace = block
+      end
+
       def with_playwright_page(&block)
         raise ArgumentError.new('block must be given') unless block
 

--- a/spec/feature/example_spec.rb
+++ b/spec/feature/example_spec.rb
@@ -21,6 +21,17 @@ RSpec.describe 'Example' do
           test_case: true,
         )
       end
+
+      Capybara.current_session.driver.on_save_trace do |trace_path|
+        next unless defined?(Allure)
+
+        Allure.add_attachment(
+          name: "trace - #{example.description}",
+          source: File.read(trace_path),
+          type: 'application/zip',
+          test_case: true,
+        )
+      end
     end
   end
 


### PR DESCRIPTION
closes #65 

This PR provides a simple and useful tracing option for Allure users.

```ruby
    before do |example|
      ...

      Capybara.current_session.driver.on_save_trace do |trace_path|
        Allure.add_attachment(
          name: "trace - #{example.description}",
          source: File.read(trace_path),
          type: 'application/zip',
          test_case: true,
        )
      end
    end
```

<img width="1159" alt="貼り付けた画像_2023_11_13_0_01" src="https://github.com/YusukeIwaki/capybara-playwright-driver/assets/11763113/520d800b-67ac-4e14-98bb-75a8bbb98a1f">

<img width="1392" alt="image" src="https://github.com/YusukeIwaki/capybara-playwright-driver/assets/11763113/a4167c32-d5e7-4631-a3b6-62d278efbeef">
