### PR TITLE
Support paths using 2-byte characters

### DIFF
--- a/capybara-playwright.gemspec
+++ b/capybara-playwright.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = '>= 2.4'
+  spec.add_dependency 'addressable'
   spec.add_dependency 'capybara'
   spec.add_dependency 'playwright-ruby-client', '>= 1.16.0'
   spec.add_development_dependency 'allure-rspec'

--- a/lib/capybara/playwright/browser.rb
+++ b/lib/capybara/playwright/browser.rb
@@ -1,3 +1,4 @@
+require 'addressable/uri'
 require_relative './tmpdir_owner'
 
 module Capybara
@@ -74,9 +75,9 @@ module Capybara
         assert_page_alive {
           url =
           if Capybara.app_host
-            URI(Capybara.app_host).merge(path)
+            Addressable::URI.parse(Capybara.app_host) + path
           elsif Capybara.default_host
-            URI(Capybara.default_host).merge(path)
+            Addressable::URI.parse(Capybara.default_host) + path
           else
             path
           end

--- a/spec/feature/assertion_spec.rb
+++ b/spec/feature/assertion_spec.rb
@@ -39,6 +39,10 @@ RSpec.describe 'assertion', sinatra: true do
     sinatra.get '/finish.html' do
       'finish'
     end
+
+    sinatra.get '/猫' do
+      'cat'
+    end
   end
 
   it 'survives against navigation' do
@@ -55,5 +59,11 @@ RSpec.describe 'assertion', sinatra: true do
     sleep 0.5
     refresh
     expect(page).to have_content('finish')
+  end
+
+  it 'can access paths using 2-byte characters' do
+    visit '/猫'
+
+    expect(page).to have_content('cat')
   end
 end


### PR DESCRIPTION
The following error occurs when the path contains 2-byte characters.

```
URI::InvalidURIError:
  URI must be ascii only "http://localhost:4567/\u732B"
```

Referring to the Capybara implementation, use Addressable instead of URI
to support 2-byte characters.
refs: https://github.com/teamcapybara/capybara/blob/3.40.0/lib/capybara/session.rb#L261
