### PR TITLE
Fix connect to connect_to_playwright_server

### DIFF
--- a/lib/capybara/playwright/browser_runner.rb
+++ b/lib/capybara/playwright/browser_runner.rb
@@ -26,7 +26,7 @@ module Capybara
           end
 
           def playwright_execution
-            @playwright_execution ||= ::Playwright.connect_to_playwright_server(@ws_endpoint)
+            @playwright_execution ||= ::Playwright.connect_to_playwright_server("#{@ws_endpoint}?browser=#{@browser_type}")
           end
 
           def playwright_browser


### PR DESCRIPTION
Hello,
I'm trying to use Plawright with docker as a websocker.

When passing a websocket url (eg: `ws://localhost:8888/ws`) there is an error when connecting to browser.

`Minitest::UnexpectedError:         Playwright::Error: Cannot read properties of undefined (reading 'launch')`

here is how Playwright driver is added to Capybara:

```
Capybara.register_driver(:playwright) do |app|
  Capybara::Playwright::Driver.new(app,
                                   browser_type: :chromium,
                                   headless: false)
end

class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
  driven_by(
      :playwright,
      using: :chromium,
      options: {
        playwright_server_endpoint_url: 'ws://localhost:8888/ws'
      } 
    )
end
  ```
  
  adding `?browser=#{@browser_type}` fix the issue and I'm able to use Playwright with Capybara and docker.
  
  Thanks for helping !
