### PR TITLE
Node#visible_text use scrub to replace invalid UTF-8 sequences

### DIFF
--- a/lib/capybara/playwright/node.rb
+++ b/lib/capybara/playwright/node.rb
@@ -131,7 +131,7 @@ module Capybara
               }
             }
           JAVASCRIPT
-          text.to_s.gsub(/\A[[:space:]&&[^\u00a0]]+/, '')
+          text.to_s.scrub.gsub(/\A[[:space:]&&[^\u00a0]]+/, '')
               .gsub(/[[:space:]&&[^\u00a0]]+\z/, '')
               .gsub(/\n+/, "\n")
               .tr("\u00a0", ' ')


### PR DESCRIPTION
Some pages cause a `invalid byte sequence in UTF-8` exception to be raised when calling `text.to_s.gsub(/\A[[:space:]&&[^\u00a0]]+/, '')`. Adding [`scrub`](https://rubyapi.org/3.3/o/string#method-i-scrub) prevents this.

Specific context:
It seems a `&nbsp;` HTML entity gets interpreted as "\xA0", or byte 160, which has an invalid encoding. Using [`charlock_homes`](https://github.com/brianmario/charlock_holmes) the encoding of the entire page is reported as `ISO-8859-1` with 54% confidence.