### PR TITLE
Fix silent test pass

### DIFF
--- a/lib/capybara/playwright/driver_extension.rb
+++ b/lib/capybara/playwright/driver_extension.rb
@@ -46,7 +46,7 @@ module Capybara
       def with_playwright_page(&block)
         raise ArgumentError.new('block must be given') unless block
 
-        @browser&.with_playwright_page(&block)
+        browser.with_playwright_page(&block)
       end
 
       # Start Playwright tracing (doc: https://playwright.dev/docs/api/class-tracing#tracing-start)

--- a/spec/feature/example_spec.rb
+++ b/spec/feature/example_spec.rb
@@ -91,4 +91,12 @@ RSpec.describe 'Example' do
       puts "#{li.with_playwright_element_handle { |handle| handle.text_content }} by Playwright"
     end
   end
+
+  it 'does not silently pass when browser has not been started' do
+    expect do
+      page.driver.with_playwright_page do |_page|
+        raise 'this block actually executed'
+      end
+    end.to raise_error(RuntimeError, 'this block actually executed')
+  end
 end


### PR DESCRIPTION
I want to use Playwright's API exclusively (without capybara's API), but I noticed that my tests would pass without doing anything unless I called `capybara's` visit first. 

I managed to track it down to the `@browser&.with_playwright_page`. So I replaced it with `browser` method, which seems to instantiate the browser.

I also think the save navigation here should be avoided. If `browser` is nil we should raise a no-method error instead of doing nothing.

This error is reproduced in specs, but I'm open for suggestions if you have an idea to do it better.