### PR TITLE
[Bugfix] Allow lowercase strings in `send_keys`

### DIFF
--- a/lib/capybara/playwright/node.rb
+++ b/lib/capybara/playwright/node.rb
@@ -600,6 +600,10 @@ module Capybara
 
         class PressKey
           def initialize(key:, modifiers:)
+            # Shift always requires uppercase key
+            # See https://playwright.dev/docs/input#keys-and-shortcuts
+            key.upcase! if modifiers.include?(MODIFIERS[:shift])
+
             # puts "PressKey: key=#{key} modifiers: #{modifiers}"
             if modifiers.empty?
               @key = key

--- a/lib/capybara/playwright/node.rb
+++ b/lib/capybara/playwright/node.rb
@@ -602,7 +602,7 @@ module Capybara
           def initialize(key:, modifiers:)
             # Shift always requires uppercase key
             # See https://playwright.dev/docs/input#keys-and-shortcuts
-            key.upcase! if modifiers.include?(MODIFIERS[:shift])
+            key = key.upcase if modifiers.include?(MODIFIERS[:shift])
 
             # puts "PressKey: key=#{key} modifiers: #{modifiers}"
             if modifiers.empty?

--- a/lib/capybara/playwright/node.rb
+++ b/lib/capybara/playwright/node.rb
@@ -548,7 +548,7 @@ module Capybara
                   _key = key.last
                   code =
                     if _key.is_a?(String) && _key.length == 1
-                      _key.upcase
+                      _key
                     elsif _key.is_a?(Symbol)
                       key_for(_key)
                     else
@@ -567,7 +567,7 @@ module Capybara
                 when String
                   key.each_char do |char|
                     executables << PressKey.new(
-                      key: char.upcase,
+                      key: char,
                       modifiers: modifiers,
                     )
                   end

--- a/spec/feature/example_spec.rb
+++ b/spec/feature/example_spec.rb
@@ -91,4 +91,22 @@ RSpec.describe 'Example' do
       puts "#{li.with_playwright_element_handle { |handle| handle.text_content }} by Playwright"
     end
   end
+
+  it 'can send keys with modifier' do
+    Capybara.app_host = 'https://github.com'
+    visit '/'
+
+    page.send_keys ['s']
+
+    expect(page).to have_field('query-builder-test')
+  end
+
+  it 'can send keys with modifier' do
+    Capybara.app_host = 'https://tailwindcss.com/'
+    visit '/'
+
+    page.send_keys [:control, 'k']
+
+    expect(page).to have_field('docsearch-input')
+  end
 end

--- a/spec/feature/example_spec.rb
+++ b/spec/feature/example_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe 'Example' do
     end
   end
 
-  it 'can send keys with modifier' do
+  it 'can send keys without modifier' do
     Capybara.app_host = 'https://github.com'
     visit '/'
 

--- a/spec/feature/example_spec.rb
+++ b/spec/feature/example_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe 'Example' do
     Capybara.app_host = 'https://github.com'
     visit '/'
 
-    page.send_keys ['s']
+    find('body').send_keys ['s']
 
     expect(page).to have_field('query-builder-test')
   end
@@ -105,7 +105,7 @@ RSpec.describe 'Example' do
     Capybara.app_host = 'https://tailwindcss.com/'
     visit '/'
 
-    page.send_keys [:control, 'k']
+    find('body').send_keys [:control, 'k']
 
     expect(page).to have_field('docsearch-input')
   end


### PR DESCRIPTION
### Summary

This PR provides functionality that allows callers to specify lowercase keys in `send_keys`, something not currently supported as they are always uppercased unless they are sent as an individual string.

### Background

I'd like to write a test to validate behavior for opening a window with `send_keys [:control, 'k']`, but that's not possible because the keys are implicitly uppercased in this library. Note that this same command works using a Selenium driver.

A possible workaround for existing versions is below, but ought to be supported outright.
```ruby
page.driver.with_playwright_page do |page|
  page.keyboard.press('Control+k') # note this isn't `press('Control+K')`
end
```

I've added a test to this PR that confirms the correct behavior on sites that include shortcuts with modifiers (Tailwind) and without (Github).