### PR TITLE
Do not override `:wait` for non-Playwright drivers

### DIFF
--- a/lib/capybara/playwright/node.rb
+++ b/lib/capybara/playwright/node.rb
@@ -8,7 +8,10 @@ module Capybara
 
       # Playwright has own auto-waiting feature.
       # So disable Capybara's retry logic.
-      options[:wait] = 0
+      if driver.is_a?(Capybara::Playwright::Driver)
+        options[:wait] = 0
+      end
+
       super
     end
   end


### PR DESCRIPTION
Do not override `:wait` when the current driver is not Playwright. This was causing our suite to fail just by requiring
`capybara-playwright-driver`.