### PR TITLE
[Bugfix] Do not modify special keys

### DIFF
--- a/lib/capybara/playwright/node.rb
+++ b/lib/capybara/playwright/node.rb
@@ -602,7 +602,7 @@ module Capybara
           def initialize(key:, modifiers:)
             # Shift requires an explicitly uppercase a-z key to produce the correct output
             # See https://playwright.dev/docs/input#keys-and-shortcuts
-            key = key.upcase if modifiers.include?(MODIFIERS[:shift]) && key.match?(/^[a-z]$/)
+            key = key.upcase if modifiers == [MODIFIERS[:shift]] && key.match?(/^[a-z]$/)
 
             # puts "PressKey: key=#{key} modifiers: #{modifiers}"
             if modifiers.empty?

--- a/lib/capybara/playwright/node.rb
+++ b/lib/capybara/playwright/node.rb
@@ -600,9 +600,9 @@ module Capybara
 
         class PressKey
           def initialize(key:, modifiers:)
-            # Shift always requires uppercase key
+            # Shift requires an explicitly uppercase a-z key to produce the correct output
             # See https://playwright.dev/docs/input#keys-and-shortcuts
-            key = key.upcase if modifiers.include?(MODIFIERS[:shift])
+            key = key.upcase if modifiers.include?(MODIFIERS[:shift]) && key.match?(/^[a-z]$/)
 
             # puts "PressKey: key=#{key} modifiers: #{modifiers}"
             if modifiers.empty?

--- a/spec/feature/example_spec.rb
+++ b/spec/feature/example_spec.rb
@@ -92,22 +92,33 @@ RSpec.describe 'Example' do
     end
   end
 
-  it 'can send keys without modifier' do
-    Capybara.app_host = 'https://github.com'
-    visit '/'
+  context 'send_keys' do
+    it 'can send keys without modifier' do
+      Capybara.app_host = 'https://github.com'
+      visit '/'
 
-    find('body').send_keys ['s']
+      find('body').send_keys ['s']
 
-    expect(page).to have_field('query-builder-test')
-  end
+      expect(page).to have_field('query-builder-test')
+    end
 
-  it 'can send keys with modifier' do
-    Capybara.app_host = 'https://tailwindcss.com/'
-    visit '/'
+    it 'can send keys with modifier' do
+      Capybara.app_host = 'https://tailwindcss.com/'
+      visit '/'
 
-    find('body').send_keys [:control, 'k']
+      find('body').send_keys [:control, 'k']
 
-    expect(page).to have_field('docsearch-input')
+      expect(page).to have_field('docsearch-input')
+    end
+
+    it 'can shift+modifier' do
+      Capybara.app_host = 'https://github.com'
+      visit '/'
+
+      expect_any_instance_of(Playwright::ElementHandle).to receive(:press).with('Shift+Home')
+
+      find('body').send_keys %i[shift home]
+    end
   end
 
   it 'does not silently pass when browser has not been started' do


### PR DESCRIPTION
Fixes #88

This is a regression from https://github.com/YusukeIwaki/capybara-playwright-driver/pull/86, which is too wide-reaching in upper-casing keys combined with Shift. Instead, only explicitly uppercase the individual a-z keys that require it.

