### PR TITLE
Add reducedMotion to BrowserOption

### DIFF
--- a/lib/capybara/playwright/browser_options.rb
+++ b/lib/capybara/playwright/browser_options.rb
@@ -20,6 +20,7 @@ module Capybara
         headless: nil,
         ignoreDefaultArgs: nil,
         proxy: nil,
+        reducedMotion: nil,
         slowMo: nil,
         # timeout: nil,
         tracesDir: nil,


### PR DESCRIPTION
Fixes #99

Support the `reducedMotion` option.