### PR TITLE
Move reducedMotion to PageOption

### DIFF
--- a/lib/capybara/playwright/browser_options.rb
+++ b/lib/capybara/playwright/browser_options.rb
@@ -20,6 +20,7 @@ module Capybara
         headless: nil,
         ignoreDefaultArgs: nil,
         proxy: nil,
+        reducedMotion: nil,
         slowMo: nil,
         # timeout: nil,
         tracesDir: nil,

--- a/lib/capybara/playwright/browser_options.rb
+++ b/lib/capybara/playwright/browser_options.rb
@@ -20,7 +20,6 @@ module Capybara
         headless: nil,
         ignoreDefaultArgs: nil,
         proxy: nil,
-        reducedMotion: nil,
         slowMo: nil,
         # timeout: nil,
         tracesDir: nil,

--- a/lib/capybara/playwright/page_options.rb
+++ b/lib/capybara/playwright/page_options.rb
@@ -26,6 +26,7 @@ module Capybara
         record_har_path: nil,
         record_video_dir: nil,
         record_video_size: nil,
+        reducedMotion: nil,
         screen: nil,
         serviceWorkers: nil,
         storageState: nil,


### PR DESCRIPTION
This is a fix for https://github.com/YusukeIwaki/capybara-playwright-driver/pull/100. The `reducedMotion` option is a `PageOption`, not `BrowserOption`.

For anyone blocked by this, you can add this to your playwright initialization:
```ruby
Capybara::Playwright::PageOptions::NEW_PAGE_PARAMS.push(:reducedMotion)
Capybara::Playwright::BrowserOptions::LAUNCH_PARAMS.delete(:reducedMotion)
```