### PR TITLE
gemspec: Drop unused executables configuration

### DIFF
--- a/capybara-playwright.gemspec
+++ b/capybara-playwright.gemspec
@@ -20,8 +20,6 @@ Gem::Specification.new do |spec|
       f.match(%r{^(test|spec|features)/}) || f.include?('.git')
     end
   end
-  spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = '>= 2.4'


### PR DESCRIPTION
This gem does not expose any executables.