### PR TITLE
Resolve `namespaceURI` error on stale elements

### DIFF
--- a/lib/capybara/playwright/node.rb
+++ b/lib/capybara/playwright/node.rb
@@ -97,6 +97,8 @@ module Capybara
           raise StaleReferenceError.new(err)
         when /error in channel "content::page": exception while running method "adoptNode"/ # for Firefox
           raise StaleReferenceError.new(err)
+        when /(: Shadow DOM element - no XPath :)/
+          raise StaleReferenceError.new(err)
         else
           raise
         end
@@ -905,6 +907,9 @@ module Capybara
                 xpath = el.nodeName.toUpperCase()+"["+pos+"]/"+xpath;
               }
               el = el.parentNode;
+              if (!el) {
+                throw "(: Shadow DOM element - no XPath :)";
+              }
             }
             xpath = '/'+xml.documentElement.nodeName.toUpperCase()+'/'+xpath;
             xpath = xpath.replace(/\\/$/, '');

--- a/spec/feature/stale_element_spec.rb
+++ b/spec/feature/stale_element_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+RSpec.describe 'stale element handling' do
+  before do
+    visit 'about:blank'
+    page.driver.with_playwright_page do |page|
+      page.content = <<~HTML
+        <div id="myid"></div>
+      HTML
+    end
+  end
+
+  def rerender_element
+    page.evaluate_script(<<~JAVASCRIPT)
+      (() => {
+        const el = document.getElementById('myid');
+        const newElement = document.createElement('div');
+        newElement.id = 'myid';
+        newElement.textContent = 'New Element';
+        document.getElementById('myid').replaceWith(newElement);
+      })()
+    JAVASCRIPT
+  end
+
+  def simulate_rerender_immediately_after_enabled_check
+    # Hooks into the assert_element_not_stale method to simulate an HTML
+    # element being replaced right after the staleness check, but before the block is called.
+    original_method = Capybara::Playwright::Node.instance_method(:assert_element_not_stale)
+    allow_any_instance_of(Capybara::Playwright::Node).to receive(:assert_element_not_stale) do |instance, &blk|
+      original_method.bind(instance).call do
+        rerender_element
+        blk.call
+      end
+    end
+  end
+
+  describe 'Element#inspect' do
+    it 'works when the element is replaced between find and inspect' do
+      el = find('#myid')
+
+      rerender_element
+      expect(el.inspect).to eq('Obsolete #<Capybara::Node::Element>')
+    end
+
+    it 'works when the element is replaced immediately after the staleness check' do
+      el = find('#myid')
+
+      simulate_rerender_immediately_after_enabled_check
+      expect(el.inspect).to eq('Obsolete #<Capybara::Node::Element>')
+    end
+  end
+end


### PR DESCRIPTION
If the timing is perfect, it's possible for an element to be removed from the DOM in between the `.enabled?` check in `assert_element_not_stale` and the wrapped logic.

Most of the time that's ok, because the relevant playwright error is raised and caught. But when something calls `.inspect`, we were seeing sporadic issues like:

```
Playwright::Error:
  TypeError: Cannot read properties of null (reading 'namespaceURI')
      at eval (eval at evaluate (:290:30), <anonymous>:17:12)
      at UtilityScript.evaluate (<anonymous>:297:18)
      at UtilityScript.<anonymous> (<anonymous>:1:44)
```

This commit detects that issue in the x-path-building javascript, and handles it in assert_element_not_stale. Now this situation will correctly raise a `StaleReferenceError`.