### PR TITLE
Fix status_code race when response callbacks are delayed

### DIFF
--- a/lib/capybara/playwright/browser.rb
+++ b/lib/capybara/playwright/browser.rb
@@ -84,7 +84,8 @@ module Capybara
             path
           end
 
-          @playwright_page.capybara_current_frame.goto(url)
+          response = @playwright_page.capybara_current_frame.goto(url)
+          @playwright_page.capybara_set_last_response(response)
         }
       end
 
@@ -144,13 +145,15 @@ module Capybara
 
       def go_back
         assert_page_alive {
-          @playwright_page.go_back
+          response = @playwright_page.go_back
+          @playwright_page.capybara_set_last_response(response)
         }
       end
 
       def go_forward
         assert_page_alive {
-          @playwright_page.go_forward
+          response = @playwright_page.go_forward
+          @playwright_page.capybara_set_last_response(response)
         }
       end
 

--- a/spec/feature/status_code_race_spec.rb
+++ b/spec/feature/status_code_race_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+module ResponseCallbackDelayPatch
+  class << self
+    attr_accessor :enabled
+  end
+  self.enabled = false
+
+  def perform_event_emitter_callback(event, callback, args)
+    if ResponseCallbackDelayPatch.enabled && event == Playwright::Events::Page::Response
+      # Delay only response callback asynchronously to force out-of-order processing.
+      Thread.new do
+        sleep 0.1
+        callback.call(*args)
+      end
+      true
+    else
+      super
+    end
+  end
+end
+
+Playwright::ChannelOwners::Page.prepend(ResponseCallbackDelayPatch)
+
+RSpec.describe 'status_code race', sinatra: true do
+  before do
+    sinatra.get '/status' do
+      'ok'
+    end
+  end
+
+  around do |example|
+    ResponseCallbackDelayPatch.enabled = true
+    example.run
+  ensure
+    ResponseCallbackDelayPatch.enabled = false
+  end
+
+  it 'returns 200 immediately after visit even if response callback is delayed' do
+    10.times do |i|
+      visit "/status?i=#{i}"
+      expect(page.status_code).to eq(200)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #119 

## Summary
This PR fixes the race condition from Issue #119 where `page.status_code` can become `0`.

- Added a regression spec to reproduce the issue
  - `spec/feature/status_code_race_spec.rb`
- Removed event-order dependency from status code tracking
  - `lib/capybara/playwright/page.rb`
- Synchronously applies navigation `Response` objects returned by Playwright APIs
  - `lib/capybara/playwright/browser.rb` (`visit`, `go_back`, `go_forward`)

## Failing Reproduction Log (Before Fix)
```text
status_code race
  returns 200 immediately after visit even if response callback is delayed (FAILED - 1)

Failures:

  1) status_code race returns 200 immediately after visit even if response callback is delayed
     Failure/Error: expect(page.status_code).to eq(200)

       expected: 200
            got: 0

       (compared using ==)
     # ./spec/feature/status_code_race_spec.rb:42:in `block (3 levels) in <top (required)>'
     # ./spec/feature/status_code_race_spec.rb:40:in `block (2 levels) in <top (required)>'
     # ./spec/feature/status_code_race_spec.rb:34:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:40:in `block (2 levels) in <top (required)>'

Finished in 1.06 seconds (files took 0.34797 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/feature/status_code_race_spec.rb:39 # status_code race returns 200 immediately after visit even if response callback is delayed
```

## Verification
```bash
bundle exec rspec spec/feature/status_code_race_spec.rb \
  spec/feature/assertion_spec.rb \
  spec/feature/stale_element_spec.rb \
  spec/feature/example_spec.rb:38 \
  spec/feature/example_spec.rb:65 --format progress
```

Result: `8 examples, 0 failures`
