### PR TITLE
Mark specs failing due to Ruby 3.4 Hash#inspect change as pending

### DIFF
--- a/spec/capybara/playwright_spec.rb
+++ b/spec/capybara/playwright_spec.rb
@@ -44,6 +44,10 @@ Capybara::SpecHelper.run_specs TestSessions::Playwright, 'Playwright' do |exampl
     pending "Not sure what firefox is doing here" if ENV['BROWSER'] == 'firefox'
   when /#has_element\? should be true if the given element is on the page/
     pending 'https://github.com/teamcapybara/capybara/pull/2751'
+  when /assert_matches_style should raise error if the elements style doesn't contain the given properties/
+    pending 'https://github.com/teamcapybara/capybara/pull/2832' if RUBY_VERSION >= '3.4'
+  when /#has_css\? :style option should support Hash/
+    pending 'https://github.com/teamcapybara/capybara/pull/2832' if RUBY_VERSION >= '3.4'
   end
 
   Capybara::SpecHelper.reset!


### PR DESCRIPTION
## Summary
- Mark two Capybara specs as pending on Ruby 3.4+ that fail due to `Hash#inspect` format change (spaces around `=>`)
- The failing specs hardcode the old format in assertions; this is a Capybara upstream issue being fixed in https://github.com/teamcapybara/capybara/pull/2832

Closes #121

## Test plan
- [x] Verified specs fail on Ruby 3.4 without this change
- [x] Verified specs are pending on Ruby 3.4 with this change (0 failures)
- [x] Verified no regression on Ruby 3.3 (specs still pass normally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)