### PR TITLE
Fix close handler nullifying current page when a different page closes

### DIFF
--- a/lib/capybara/playwright/browser.rb
+++ b/lib/capybara/playwright/browser.rb
@@ -48,7 +48,7 @@ module Capybara
       private def create_page(browser_context)
         browser_context.new_page.tap do |page|
           page.on('close', -> {
-            if @playwright_page
+            if @playwright_page&.guid == page.guid
               @playwright_page = nil
             end
           })

--- a/spec/feature/window_close_spec.rb
+++ b/spec/feature/window_close_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+RSpec.describe 'closing a non-current window', sinatra: true do
+  before do
+    sinatra.get '/' do
+      '<h1>Main Page</h1>'
+    end
+
+    sinatra.get '/other' do
+      '<h1>Other Page</h1>'
+    end
+  end
+
+  it 'keeps the current page accessible after closing a different window' do
+    visit '/'
+    expect(page).to have_content('Main Page')
+
+    new_window = open_new_window(:window)
+    within_window(new_window) do
+      visit '/other'
+      expect(page).to have_content('Other Page')
+    end
+
+    new_window.close
+
+    # The current page should still be accessible (this fails before the fix)
+    expect(page).to have_content('Main Page')
+    expect(page.current_url).to include('/')
+  end
+end


### PR DESCRIPTION
## Problem

The close event handler in `create_page` unconditionally sets `@playwright_page` to `nil` when **any** page closes, not just the current one:

```ruby
page.on('close', -> {
  if @playwright_page        # checks truthy, not identity
    @playwright_page = nil
  end
})
```

When a non-current page closes (e.g. after `within_window` or `open_new_window`), the handler fires and nullifies the reference to the **current** page, causing `NoSuchWindowError` on the next operation.

Both Selenium and Cuprite handle this correctly — [repro script](https://gist.github.com/MatheusRich/c6ebcc21387469c1307280615512facc) showing all three drivers:

```
test_selenium:   PASS
test_cuprite:    PASS
test_playwright: ERROR - NoSuchWindowError
```

## Fix

Use `guid` comparison (already the pattern in `close_window`, `switch_to_window`, and `on_window`) to only nullify when the closing page is the current page:

```ruby
page.on('close', -> {
  if @playwright_page&.guid == page.guid
    @playwright_page = nil
  end
})
```