### PR TITLE
Coerce default_max_wait_time to Float before passing to Playwright

### DIFF
--- a/lib/capybara/playwright/node.rb
+++ b/lib/capybara/playwright/node.rb
@@ -258,7 +258,7 @@ module Capybara
       end
 
       private def capybara_default_wait_time
-        Capybara.default_max_wait_time * 1100 # with 10% buffer for allowing overhead.
+        Capybara.default_max_wait_time.to_f * 1100 # with 10% buffer for allowing overhead.
       end
 
       class NotActionableError < StandardError ; end

--- a/spec/feature/default_max_wait_time_spec.rb
+++ b/spec/feature/default_max_wait_time_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+RSpec.describe 'default_max_wait_time coercion', sinatra: true do
+  before do
+    sinatra.get('/checkbox') do
+      <<~HTML
+      <body>
+        <input type="checkbox" id="agree" />
+      </body>
+      HTML
+    end
+  end
+
+  # Mimics an ActiveSupport::Duration (e.g. `20.seconds`): it is not a Float,
+  # multiplication keeps it a non-Float, but it responds to #to_f. Without the
+  # coercion this value reaches playwright-ruby-client and raises
+  # "expected float, got string".
+  let(:duration_like) do
+    Class.new do
+      def initialize(value)
+        @value = value
+      end
+
+      def *(other)
+        self.class.new(@value * other)
+      end
+
+      def to_f
+        @value.to_f
+      end
+
+      def to_s
+        @value.to_s
+      end
+    end.new(5)
+  end
+
+  around do |example|
+    original_wait_time = Capybara.default_max_wait_time
+    Capybara.default_max_wait_time = duration_like
+    example.run
+    Capybara.default_max_wait_time = original_wait_time
+  end
+
+  it 'coerces a non-Float default_max_wait_time before passing it to Playwright', driver: :playwright do
+    captured_timeout = nil
+    allow_any_instance_of(Playwright::ElementHandle).to receive(:check).and_wrap_original do |method, **options|
+      captured_timeout = options[:timeout]
+      method.call(**options)
+    end
+
+    visit '/checkbox'
+    check('agree')
+
+    expect(captured_timeout).to be_a(Float)
+    expect(find('#agree')).to be_checked
+  end
+end


### PR DESCRIPTION
## Problem

`Capybara.default_max_wait_time` is forwarded to `playwright-ruby-client` without coercion in `Node#capybara_default_wait_time`:

```ruby
Capybara.default_max_wait_time * 1100
```

When `default_max_wait_time` is set to an `ActiveSupport::Duration` (e.g. `Capybara.default_max_wait_time = 20.seconds`), the multiplication yields another `Duration` rather than a `Float`. That value reaches `playwright-ruby-client`, which rejects it with:

```
expected float, got string
```

## Fix

Call `#to_f` before scaling:

```ruby
Capybara.default_max_wait_time.to_f * 1100
```

`#to_f` cleanly handles `ActiveSupport::Duration`, `Integer`, `Float`, and numeric `String` values alike, so the timeout always arrives as a `Float`.

## Test

Adds `spec/feature/default_max_wait_time_spec.rb`, which sets `default_max_wait_time` to a Duration-like object (not a `Float`, but responds to `#to_f`) and asserts that the timeout reaching Playwright is a `Float` and the interaction succeeds. The test fails on `main` and passes with this change. No new dependency (e.g. ActiveSupport) is introduced.