### PR TITLE
[codex] Fix fill_in keyup compatibility

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -102,6 +102,31 @@ jobs:
           PLAYWRIGHT_CLI_EXECUTABLE_PATH: ./node_modules/.bin/playwright
         timeout-minutes: 25
 
+  compatibility_test:
+    needs: example_spec
+    name: Compatibility Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.4
+          bundler-cache: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - name: setup playwright via npm install
+        run: |
+          export PLAYWRIGHT_CLI_VERSION=$(bundle exec ruby -e 'require "playwright"; puts Playwright::COMPATIBLE_PLAYWRIGHT_VERSION.strip')
+          npm install playwright@${PLAYWRIGHT_CLI_VERSION} || npm install playwright@next
+          ./node_modules/.bin/playwright install --with-deps chromium
+      - run: bundle exec rspec spec/compatibility/
+        env:
+          BROWSER: chromium
+          PLAYWRIGHT_CLI_EXECUTABLE_PATH: ./node_modules/.bin/playwright
+        timeout-minutes: 10
+
   playwright_driver_spec_firefox:
     needs: example_spec
     name: (firefox) Playwright Driver

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -121,9 +121,18 @@ jobs:
           export PLAYWRIGHT_CLI_VERSION=$(bundle exec ruby -e 'require "playwright"; puts Playwright::COMPATIBLE_PLAYWRIGHT_VERSION.strip')
           npm install playwright@${PLAYWRIGHT_CLI_VERSION} || npm install playwright@next
           ./node_modules/.bin/playwright install --with-deps chromium
-      - run: bundle exec rspec spec/compatibility/
+      - name: Check Chrome for Selenium
+        run: google-chrome --version
+      - name: Run compatibility tests with Selenium
+        run: bundle exec rspec spec/compatibility/
+        env:
+          COMPATIBILITY_DRIVER: selenium_chrome_headless
+        timeout-minutes: 10
+      - name: Run compatibility tests with Playwright
+        run: bundle exec rspec spec/compatibility/
         env:
           BROWSER: chromium
+          COMPATIBILITY_DRIVER: playwright
           PLAYWRIGHT_CLI_EXECUTABLE_PATH: ./node_modules/.bin/playwright
         timeout-minutes: 10
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,3 +105,11 @@ end
 ## General Guidance
 - Prefer concise Ruby that reads top-to-bottom without carrying unnecessary temporary state.
 - Prefer small private helper objects only when they reduce complexity. Once extracted, give them Ruby-like method names and keep their public surface minimal.
+
+## How to execute RSpec or Ruby
+
+`ruby` uses macOS system ruby interpreter (typically 2.6 or older). rbenv should be used.
+
+- Do not run the full `spec/capybara/playwright_spec.rb` or full RSpec suite locally; run broad coverage in GitHub Actions.
+- To run a focused Playwright compatibility check locally, use an example filter, for example:
+  `RBENV_VERSION=$(cat .ruby-version) ~/.rbenv/shims/bundle exec rspec spec/capybara/playwright_spec.rb --example fill_in`

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'rack-test_server'
 gem 'rake', '~> 13.0.3'
 gem 'rspec', '~> 3.11.0'
 gem 'rubocop-rspec'
+gem 'selenium-webdriver', '~> 4.34.0' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.2')
 gem 'sinatra', '>= 1.4.0'
 gem 'webrick'
 gem 'websocket-driver'

--- a/lib/capybara/playwright/node.rb
+++ b/lib/capybara/playwright/node.rb
@@ -411,7 +411,9 @@ module Capybara
           end
 
           text = value.to_s
-          if press_enter = text.end_with?("\n")
+          if press_enter = text.end_with?("\r\n")
+            text = text[0...-2]
+          elsif press_enter = text.end_with?("\n")
             text = text[0...-1]
           end
 
@@ -419,6 +421,7 @@ module Capybara
             @element.type(text, timeout: @timeout)
           else
             @element.fill(text, timeout: @timeout)
+            @element.dispatch_event('keyup')
           end
 
           if press_enter

--- a/lib/capybara/playwright/node.rb
+++ b/lib/capybara/playwright/node.rb
@@ -429,7 +429,9 @@ module Capybara
         end
 
         private def set_text(text, append:)
-          fill_text, typed_text = split_trailing_grapheme(text)
+          grapheme_clusters = text.scan(/\X/)
+          fill_text = grapheme_clusters[0...-1].join
+          typed_text = grapheme_clusters[-1].to_s
 
           if append
             @element.type(fill_text, timeout: @timeout) unless fill_text.empty?
@@ -437,12 +439,6 @@ module Capybara
             @element.fill(fill_text, timeout: @timeout)
           end
           @element.type(typed_text, timeout: @timeout) unless typed_text.empty?
-        end
-
-        private def split_trailing_grapheme(text)
-          grapheme_clusters = text.scan(/\X/)
-
-          [grapheme_clusters[0...-1].join, grapheme_clusters[-1].to_s]
         end
       end
 

--- a/lib/capybara/playwright/node.rb
+++ b/lib/capybara/playwright/node.rb
@@ -417,11 +417,7 @@ module Capybara
             text = text[0...-1]
           end
 
-          if @element.evaluate('el => el.isContentEditable') && options[:clear] != :none
-            @element.fill(text, timeout: @timeout)
-          else
-            set_text(text, append: options[:clear] == :none)
-          end
+          set_text(text, append: options[:clear] == :none)
 
           if press_enter
             @element.press('Enter', timeout: @timeout)
@@ -433,6 +429,12 @@ module Capybara
         end
 
         private def set_text(text, append:)
+          # ElementHandle#type can refocus inherited contenteditable descendants and drop the input.
+          if @element.evaluate('el => el.isContentEditable') && !append
+            @element.fill(text, timeout: @timeout)
+            return
+          end
+
           grapheme_clusters = text.scan(/\X/)
           fill_text = grapheme_clusters[0...-1].join
           typed_text = grapheme_clusters[-1].to_s

--- a/lib/capybara/playwright/node.rb
+++ b/lib/capybara/playwright/node.rb
@@ -417,7 +417,11 @@ module Capybara
             text = text[0...-1]
           end
 
-          set_text(text, append: options[:clear] == :none)
+          if @element.evaluate('el => el.isContentEditable') && options[:clear] != :none
+            @element.fill(text, timeout: @timeout)
+          else
+            set_text(text, append: options[:clear] == :none)
+          end
 
           if press_enter
             @element.press('Enter', timeout: @timeout)

--- a/lib/capybara/playwright/node.rb
+++ b/lib/capybara/playwright/node.rb
@@ -417,12 +417,7 @@ module Capybara
             text = text[0...-1]
           end
 
-          if options[:clear] == :none
-            @element.type(text, timeout: @timeout)
-          else
-            @element.fill(text, timeout: @timeout)
-            @element.dispatch_event('keyup')
-          end
+          set_text(text, append: options[:clear] == :none)
 
           if press_enter
             @element.press('Enter', timeout: @timeout)
@@ -431,6 +426,23 @@ module Capybara
           raise if @element.editable?
 
           @internal_logger.info("Node#set: element is not editable. #{@element}")
+        end
+
+        private def set_text(text, append:)
+          fill_text, typed_text = split_trailing_grapheme(text)
+
+          if append
+            @element.type(fill_text, timeout: @timeout) unless fill_text.empty?
+          else
+            @element.fill(fill_text, timeout: @timeout)
+          end
+          @element.type(typed_text, timeout: @timeout) unless typed_text.empty?
+        end
+
+        private def split_trailing_grapheme(text)
+          grapheme_clusters = text.scan(/\X/)
+
+          [grapheme_clusters[0...-1].join, grapheme_clusters[-1].to_s]
         end
       end
 

--- a/spec/compatibility/fill_in_spec.rb
+++ b/spec/compatibility/fill_in_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'selenium-webdriver'
+
+RSpec.describe 'fill_in compatibility', type: :feature, sinatra: true do
+  before do
+    sinatra.get '/' do
+      <<~HTML
+        <!DOCTYPE html>
+        <html>
+        <body>
+          <label for="body">Body</label>
+          <textarea id="body" name="body"></textarea>
+          <div id="preview"></div>
+          <script>
+            body.addEventListener('keyup', function() {
+              preview.textContent = body.value;
+            });
+          </script>
+        </body>
+        </html>
+      HTML
+    end
+  end
+
+  shared_examples 'keyup-compatible fill_in' do |driver_name|
+    it "triggers keyup events with #{driver_name}" do
+      Capybara.using_driver(driver_name) do
+        visit '/'
+
+        fill_in 'Body', with: 'updated FAQ'
+
+        expect(find(:fillable_field, 'Body').value).to eq('updated FAQ')
+        expect(find(:css, '#preview')).to have_text('updated FAQ')
+      end
+    end
+  end
+
+  include_examples 'keyup-compatible fill_in', :selenium_chrome_headless
+  include_examples 'keyup-compatible fill_in', :playwright
+end

--- a/spec/compatibility/fill_in_spec.rb
+++ b/spec/compatibility/fill_in_spec.rb
@@ -37,6 +37,12 @@ RSpec.describe 'fill_in compatibility', type: :feature, sinatra: true do
     end
   end
 
-  include_examples 'keyup-compatible fill_in', :selenium_chrome_headless
-  include_examples 'keyup-compatible fill_in', :playwright
+  compatibility_drivers = ENV.fetch('COMPATIBILITY_DRIVER', 'selenium_chrome_headless,playwright')
+                             .split(',')
+                             .map(&:strip)
+                             .map(&:to_sym)
+
+  compatibility_drivers.each do |driver_name|
+    include_examples 'keyup-compatible fill_in', driver_name
+  end
 end


### PR DESCRIPTION
## Summary

Fixes #98 by making Playwright-backed `fill_in` compatible with Selenium for keyup-driven text controls.

- Adds a compatibility spec for the keyup preview case and lets CI run it separately with Selenium and Playwright in one job.
- Adds a GitHub Actions compatibility job that runs Selenium first, then Playwright.
- Keeps Playwright `fill` for the fast replacement path, then sends the final grapheme cluster through `type` so key events are produced without typing the whole value.
- Uses the same final-character path for `clear: :none`, switching only whether the prefix is appended with `type` or replaced with `fill`.
- Keeps contenteditable replacement on the `fill` path, because inherited contenteditable descendants can lose input when `ElementHandle#type` refocuses them.
- Keeps CRLF-ending textarea handling explicit so trailing Enter behavior remains compatible.
- Documents local RSpec guidance in `AGENTS.md`, including using focused `playwright_spec` example filters and leaving broad runs to GitHub Actions.

## Root Cause

The Playwright driver used `ElementHandle#fill` for normal text inputs. That updates the element value and input/change behavior, but it does not emit keyboard events such as `keyup`. Selenium `fill_in` triggers key events, so keyup-driven UI previews updated under Selenium but stayed blank under this driver.

During follow-up testing, `fill(prefix) + type(last)` also exposed a contenteditable edge case: for a child element that is editable only by inheriting `contenteditable` from its parent, `fill` leaves the selection in the child text node, but `ElementHandle#type` refocuses the child handle. Since that child is not the editing host, focus is lost and the typed final character is dropped. The implementation therefore keeps replacement for contenteditable elements on `fill(text)` and applies final-character typing to normal text controls.

## Validation

Local focused checks:

```sh
COMPATIBILITY_DRIVER=selenium_chrome_headless RBENV_VERSION=$(cat .ruby-version) ~/.rbenv/shims/bundle exec rspec --format documentation spec/compatibility/fill_in_spec.rb
COMPATIBILITY_DRIVER=playwright RBENV_VERSION=$(cat .ruby-version) ~/.rbenv/shims/bundle exec rspec --format documentation spec/compatibility/fill_in_spec.rb
RBENV_VERSION=$(cat .ruby-version) ~/.rbenv/shims/bundle exec rspec --format documentation spec/capybara/playwright_spec.rb --example contenteditable
RBENV_VERSION=$(cat .ruby-version) ~/.rbenv/shims/bundle exec rspec --format documentation spec/capybara/playwright_spec.rb --example fill_in
RBENV_VERSION=$(cat .ruby-version) ~/.rbenv/shims/bundle exec rspec --format documentation spec/feature/fill_options_spec.rb
RBENV_VERSION=$(cat .ruby-version) ~/.rbenv/shims/ruby -e "require 'yaml'; YAML.load_file('.github/workflows/rspec.yml'); puts 'workflow yaml ok'"
```

Broad/full RSpec coverage was intentionally not run locally; it should run in GitHub Actions.