### PR TITLE
[codex] Align window size with Selenium

### DIFF
--- a/lib/capybara/playwright/browser.rb
+++ b/lib/capybara/playwright/browser.rb
@@ -329,14 +329,33 @@ module Capybara
 
       def window_size(handle)
         on_window(handle) do |page|
-          page.evaluate('() => [window.innerWidth, window.innerHeight]')
+          outer_window_size(page)
         end
       end
 
       def resize_window_to(handle, width, height)
         on_window(handle) do |page|
-          page.viewport_size = { width: width, height: height }
+          page.viewport_size = viewport_size_for(page, width, height)
         end
+      end
+
+      # Capybara follows Selenium's outer window size semantics.
+      private def outer_window_size(page)
+        page.evaluate('() => [window.outerWidth || window.innerWidth, window.outerHeight || window.innerHeight]')
+      end
+
+      private def viewport_size_for(page, width, height)
+        inset_width, inset_height = page.evaluate(<<~JAVASCRIPT)
+          () => [
+            Math.max(0, (window.outerWidth || window.innerWidth) - window.innerWidth),
+            Math.max(0, (window.outerHeight || window.innerHeight) - window.innerHeight)
+          ]
+        JAVASCRIPT
+
+        {
+          width: [width - inset_width, 0].max,
+          height: [height - inset_height, 0].max
+        }
       end
 
       def maximize_window(handle)

--- a/spec/capybara/playwright_spec.rb
+++ b/spec/capybara/playwright_spec.rb
@@ -34,9 +34,6 @@ Capybara::SpecHelper.run_specs TestSessions::Playwright, 'Playwright' do |exampl
     pending 'HTML5 validation message is a bit different.' if ENV['BROWSER'] == 'webkit'
   when /shadow_root should produce error messages when failing/
     pending "Probably Capybara would assume only Selenium driver."
-  when /fill_in should handle carriage returns with line feeds in a textarea correctly/
-    # https://github.com/teamcapybara/capybara/commit/a9dd889b640759925bd04c4991de086160242fae#diff-b62b86ae4de5582bd37146266622e3debbdcab6bab6e95f522185c6a4269067dR82
-    pending "Not sure what firefox is doing here" if ENV['BROWSER'] == 'firefox'
   when /#has_element\? should be true if the given element is on the page/
     pending 'https://github.com/teamcapybara/capybara/pull/2751'
   when /assert_matches_style should raise error if the elements style doesn't contain the given properties/


### PR DESCRIPTION
## Summary

- Make `Capybara::Window#size` report the outer browser window size, matching Selenium/WebDriver semantics.
- Convert `resize_to(width, height)` from requested outer window size to the Playwright viewport size by subtracting the current browser chrome inset.
- Remove the stale Firefox pending for the textarea CRLF `fill_in` spec, which now passes after the recent fill-in fixes.

## Background

The latest `main` was failing CI on Firefox with:

- `fill_in should handle carriage returns with line feeds in a textarea correctly FIXED`
- `Capybara::Window#size should return size of whole window`
- `Capybara::Window#size should switch to original window if invoked not for current window`

The `fill_in` failure was caused by an obsolete Firefox-specific pending: the actual Capybara spec now passes.

For the window failures, Playwright 1.61+ with bundled Firefox 151 reports `window.outerHeight` larger than the viewport height. Investigation showed that Firefox WebDriver BiDi has traditionally exposed this outer/inner difference, and Selenium Firefox returns the outer window size from `browser.manage.window.size`:

```text
Selenium Firefox 150.0.2:
manage.window.size        [1366, 768]
window.innerWidth/Height  [1366, 683]
window.outerWidth/Height  [1366, 768]

after resize_to(1280, 720):
manage.window.size        [1280, 720]
window.innerWidth/Height  [1280, 635]
window.outerWidth/Height  [1280, 720]
```

This PR therefore treats Selenium's `browser.manage.window.size` behavior as the source of truth for `capybara-playwright-driver` and aligns the Playwright driver with Capybara's Selenium-compatible window contract.

## Validation

Focused checks run locally with Ruby 3.4.9 and Playwright 1.61.1:

```bash
CI=1 BROWSER=firefox bundle exec rspec spec/capybara/playwright_spec.rb --example "fill_in should handle carriage returns with line feeds" --example "Window#size should return size of whole window" --example "Window#size should switch to original window"
CI=1 BROWSER=firefox bundle exec rspec spec/capybara/playwright_spec.rb --example "Window#resize_to"
CI=1 BROWSER=chromium bundle exec rspec spec/capybara/playwright_spec.rb --example "Window#size should return size of whole window" --example "Window#size should switch to original window"
CI=1 BROWSER=chromium bundle exec rspec spec/capybara/playwright_spec.rb --example "Window#resize_to"
CI=1 BROWSER=webkit bundle exec rspec spec/capybara/playwright_spec.rb --example "Window#size should return size of whole window" --example "Window#size should switch to original window"
CI=1 BROWSER=webkit bundle exec rspec spec/capybara/playwright_spec.rb --example "Window#resize_to"
```

All focused RSpec checks passed.

`bundle exec rubocop lib/capybara/playwright/browser.rb spec/capybara/playwright_spec.rb` was also attempted, but the repo's current RuboCop setup reports unconfigured new cops and existing offenses unrelated to this change.