### PR TITLE
 Check compatibility with the Playwright Node module

### DIFF
--- a/lib/capybara/playwright/browser_runner.rb
+++ b/lib/capybara/playwright/browser_runner.rb
@@ -66,8 +66,12 @@ module Capybara
             @browser_options = BrowserOptions.new(options)
           end
 
-          def _fetch_node_version
-            node_module_version = `#{@playwright_cli_executable_path} --version`
+          def get_version_from_playwright_cli
+            `#{@playwright_cli_executable_path} --version`
+          end
+
+          def fetch_node_module_version
+            node_module_version = get_version_from_playwright_cli
             regex = /Version (\d+\.\d+\.\d+)/
 
             extracted_version = node_module_version.match(regex)&.captures&.first
@@ -78,14 +82,17 @@ module Capybara
             extracted_version
           end
 
-          def playwright_execution
-            node_module_version = _fetch_node_version
+          def check_version_compatibility
+            node_module_version = fetch_node_module_version
             compatible_version = ::Playwright::COMPATIBLE_PLAYWRIGHT_VERSION
 
-            if node_module_version.strip != compatible_version
-              raise "Incompatible Playwright version. Found: #{node_module_version.strip.inspect}. Expected: #{compatible_version}. Please install the compatible version of Playwright:\nnpm install playwright@#{compatible_version }"
-            end
+            return if node_module_version.strip == compatible_version
 
+            raise "Incompatible Playwright version. Found: #{node_module_version.strip.inspect}. Expected: #{compatible_version}. Please install the compatible version of Playwright:\nnpm install playwright@#{compatible_version }"
+          end
+
+          def playwright_execution
+            check_version_compatibility
             @playwright_execution ||= ::Playwright.create(
               playwright_cli_executable_path: @playwright_cli_executable_path,
             )

--- a/lib/capybara/playwright/browser_runner.rb
+++ b/lib/capybara/playwright/browser_runner.rb
@@ -1,3 +1,5 @@
+require 'open3'
+
 module Capybara
     module Playwright
       # playwright-ruby-client provides 3 methods to launch/connect browser.
@@ -68,31 +70,6 @@ module Capybara
             check_version_compatibility
           end
 
-          def get_version_from_playwright_cli
-            `#{@playwright_cli_executable_path} --version`
-          end
-
-          def fetch_node_module_version
-            node_module_version = get_version_from_playwright_cli
-            regex = /Version (\d+\.\d+\.\d+)/
-
-            extracted_version = node_module_version.match(regex)&.captures&.first
-            if extracted_version.nil?
-              raise "Could not extract Playwright version from output: #{node_module_version.inspect}"
-            end
-
-            extracted_version
-          end
-
-          def check_version_compatibility
-            node_module_version = fetch_node_module_version
-            compatible_version = ::Playwright::COMPATIBLE_PLAYWRIGHT_VERSION
-
-            return if node_module_version.strip == compatible_version
-
-            raise "Playwright version mismatch. Found: #{node_module_version.strip.inspect}. Expected: #{compatible_version}. Please install the compatible version of Playwright:\nnpm install playwright@#{compatible_version }"
-          end
-
           def playwright_execution
             @playwright_execution ||= ::Playwright.create(
               playwright_cli_executable_path: @playwright_cli_executable_path,
@@ -103,6 +80,30 @@ module Capybara
             browser_type = playwright_execution.playwright.send(@browser_type)
             browser_options = @browser_options.value
             browser_type.launch(**browser_options)
+          end
+
+          private
+
+          def playwright_cli_version
+            stdout, stderr, status = Open3.capture3("#{@playwright_cli_executable_path} --version")
+            unless status.success?
+              output = stderr.empty? ? stdout : stderr
+              raise "Could not get Playwright version (exit #{status.exitstatus}): #{output.strip.inspect}"
+            end
+
+            stdout[/Version\s+(\S+)/, 1] ||
+              raise("Could not extract Playwright version from output: #{stdout.inspect}")
+          end
+
+          def check_version_compatibility
+            node_module_version = playwright_cli_version
+            compatible_version = ::Playwright::COMPATIBLE_PLAYWRIGHT_VERSION.strip
+
+            return if node_module_version == compatible_version
+
+            raise "Playwright version mismatch. Found: #{node_module_version.inspect}. " \
+              "Expected: #{compatible_version}.\nPlease install the compatible version of Playwright:\n" \
+              "npm install playwright@#{compatible_version}"
           end
         end
 

--- a/lib/capybara/playwright/browser_runner.rb
+++ b/lib/capybara/playwright/browser_runner.rb
@@ -64,6 +64,8 @@ module Capybara
               raise ArgumentError.new("Unknown browser_type: #{@browser_type}")
             end
             @browser_options = BrowserOptions.new(options)
+
+            check_version_compatibility
           end
 
           def get_version_from_playwright_cli
@@ -88,11 +90,10 @@ module Capybara
 
             return if node_module_version.strip == compatible_version
 
-            raise "Incompatible Playwright version. Found: #{node_module_version.strip.inspect}. Expected: #{compatible_version}. Please install the compatible version of Playwright:\nnpm install playwright@#{compatible_version }"
+            raise "Playwright version mismatch. Found: #{node_module_version.strip.inspect}. Expected: #{compatible_version}. Please install the compatible version of Playwright:\nnpm install playwright@#{compatible_version }"
           end
 
           def playwright_execution
-            check_version_compatibility
             @playwright_execution ||= ::Playwright.create(
               playwright_cli_executable_path: @playwright_cli_executable_path,
             )

--- a/lib/capybara/playwright/browser_runner.rb
+++ b/lib/capybara/playwright/browser_runner.rb
@@ -66,7 +66,26 @@ module Capybara
             @browser_options = BrowserOptions.new(options)
           end
 
+          def _fetch_node_version
+            node_module_version = `#{@playwright_cli_executable_path} --version`
+            regex = /Version (\d+\.\d+\.\d+)/
+
+            extracted_version = node_module_version.match(regex)&.captures&.first
+            if extracted_version.nil?
+              raise "Could not extract Playwright version from output: #{node_module_version.inspect}"
+            end
+
+            extracted_version
+          end
+
           def playwright_execution
+            node_module_version = _fetch_node_version
+            compatible_version = ::Playwright::COMPATIBLE_PLAYWRIGHT_VERSION
+
+            if node_module_version.strip != compatible_version
+              raise "Incompatible Playwright version. Found: #{node_module_version.strip.inspect}. Expected: #{compatible_version}. Please install the compatible version of Playwright:\nnpm install playwright@#{compatible_version }"
+            end
+
             @playwright_execution ||= ::Playwright.create(
               playwright_cli_executable_path: @playwright_cli_executable_path,
             )

--- a/spec/compatibility/node/init_spec.rb
+++ b/spec/compatibility/node/init_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Capybara::Playwright::BrowserRunner::PlaywrightCreate do # rubocop:disable Metrics/BlockLength
+  let(:options) { {} }
+  context 'when version matches' do
+    before do
+      allow_any_instance_of(described_class).to receive(:get_version_from_playwright_cli).and_return('Version 1.62.1')
+      stub_const('Playwright::COMPATIBLE_PLAYWRIGHT_VERSION', '1.62.1')
+    end
+
+    it 'does not raise an error' do
+      expect { described_class.new(options) }.not_to raise_error
+    end
+  end
+
+  context 'when version does not match' do
+    before do
+      allow_any_instance_of(described_class).to receive(:get_version_from_playwright_cli).and_return('Version 1.61.0')
+      stub_const('Playwright::COMPATIBLE_PLAYWRIGHT_VERSION', '1.62.1')
+    end
+
+    it 'raises an error' do
+      expect do
+        described_class.new(options)
+      end.to raise_error(RuntimeError, /Playwright version mismatch/)
+    end
+  end
+
+  context 'when playwright CLI output is unexpected' do
+    before do
+      allow_any_instance_of(described_class).to receive(:get_version_from_playwright_cli).and_return('Unexpected output')
+    end
+
+    it 'raises an error' do
+      expect do
+        described_class.new(options)
+      end.to raise_error(RuntimeError, /Could not extract Playwright version/) # rubocop:disable Lint/Syntax
+    end
+  end
+end

--- a/spec/compatibility/node/init_spec.rb
+++ b/spec/compatibility/node/init_spec.rb
@@ -4,11 +4,17 @@ require 'spec_helper'
 
 RSpec.describe Capybara::Playwright::BrowserRunner::PlaywrightCreate do # rubocop:disable Metrics/BlockLength
   let(:options) { {} }
+  let(:playwright_cli_error) { '' }
+  let(:status) { instance_double(Process::Status, success?: true) }
+
+  before do
+    allow(Open3).to receive(:capture3).and_return([playwright_cli_output, playwright_cli_error, status])
+  end
+
   context 'when version matches' do
-    before do
-      allow_any_instance_of(described_class).to receive(:get_version_from_playwright_cli).and_return('Version 1.62.1')
-      stub_const('Playwright::COMPATIBLE_PLAYWRIGHT_VERSION', '1.62.1')
-    end
+    let(:playwright_cli_output) { 'Version 1.62.1' }
+
+    before { stub_const('Playwright::COMPATIBLE_PLAYWRIGHT_VERSION', '1.62.1') }
 
     it 'does not raise an error' do
       expect { described_class.new(options) }.not_to raise_error
@@ -16,10 +22,21 @@ RSpec.describe Capybara::Playwright::BrowserRunner::PlaywrightCreate do # ruboco
   end
 
   context 'when version does not match' do
-    before do
-      allow_any_instance_of(described_class).to receive(:get_version_from_playwright_cli).and_return('Version 1.61.0')
-      stub_const('Playwright::COMPATIBLE_PLAYWRIGHT_VERSION', '1.62.1')
+    let(:playwright_cli_output) { 'Version 1.61.0' }
+
+    before { stub_const('Playwright::COMPATIBLE_PLAYWRIGHT_VERSION', '1.62.1') }
+
+    it 'raises an error' do
+      expect do
+        described_class.new(options)
+      end.to raise_error(RuntimeError, /Playwright version mismatch/)
     end
+  end
+
+  context 'when a prerelease has the same numeric version' do
+    let(:playwright_cli_output) { 'Version 1.62.1-next-20260811' }
+
+    before { stub_const('Playwright::COMPATIBLE_PLAYWRIGHT_VERSION', '1.62.1') }
 
     it 'raises an error' do
       expect do
@@ -29,14 +46,24 @@ RSpec.describe Capybara::Playwright::BrowserRunner::PlaywrightCreate do # ruboco
   end
 
   context 'when playwright CLI output is unexpected' do
-    before do
-      allow_any_instance_of(described_class).to receive(:get_version_from_playwright_cli).and_return('Unexpected output')
-    end
+    let(:playwright_cli_output) { 'Unexpected output' }
 
     it 'raises an error' do
       expect do
         described_class.new(options)
-      end.to raise_error(RuntimeError, /Could not extract Playwright version/) # rubocop:disable Lint/Syntax
+      end.to raise_error(RuntimeError, /Could not extract Playwright version/)
+    end
+  end
+
+  context 'when the playwright CLI command fails' do
+    let(:playwright_cli_output) { '' }
+    let(:playwright_cli_error) { 'playwright: command not found' }
+    let(:status) { instance_double(Process::Status, success?: false, exitstatus: 127) }
+
+    it 'raises an error with the command failure' do
+      expect do
+        described_class.new(options)
+      end.to raise_error(RuntimeError, /Could not get Playwright version \(exit 127\)/)
     end
   end
 end


### PR DESCRIPTION
The Ruby client and the Playwright Node module must use compatible versions. Until now, an incompatible installation was only discovered later through cryptic protocol errors during otherwise valid operations such as `Capybara.page.current_window.resize_to(1280, 800)`:

```log
Playwright::Error:
  timeout: expected number, got undefined
```

This change checks the installed Node module when the Playwright runner is initialized. It:

- reads the installed version from the configured Playwright CLI
- compares it with `Playwright::COMPATIBLE_PLAYWRIGHT_VERSION`
- raises an explicit error with the found and expected versions, including the matching `npm install` command
- reports unexpected CLI version output separately

Specs cover matching versions, mismatching versions, and unexpected CLI output.


Mismatch is now logged as following:

```log
Failure/Error:
  raise "Playwright version mismatch. Found: #{node_module_version.inspect}. " \
    "Expected: #{compatible_version}.\nPlease install the compatible version of Playwright:\n" \
    "npm install playwright@#{compatible_version}"

RuntimeError:
  Playwright version mismatch. Found: "1.61.0". Expected: 1.62.1.
  Please install the compatible version of Playwright:
  npm install playwright@1.62.1
```