### PR TITLE
Fix negative number field input

### DIFF
--- a/lib/capybara/playwright/node.rb
+++ b/lib/capybara/playwright/node.rb
@@ -440,6 +440,11 @@ module Capybara
             return
           end
 
+          if number_input? && !append
+            replace_number_text(text)
+            return
+          end
+
           grapheme_clusters = text.scan(/\X/)
           fill_text = grapheme_clusters[0...-1].join
           typed_text = grapheme_clusters[-1].to_s
@@ -450,6 +455,20 @@ module Capybara
             @element.fill(fill_text, timeout: @timeout)
           end
           @element.type(typed_text, timeout: @timeout) unless typed_text.empty?
+        end
+
+        private def number_input?
+          @element.evaluate('el => el.type === "number"')
+        end
+
+        private def replace_number_text(text)
+          if text.empty?
+            @element.fill('', timeout: @timeout)
+            return
+          end
+
+          @element.select_text(timeout: @timeout)
+          @element.type(text, timeout: @timeout)
         end
 
         private def type_tab_separated_text(text, append:)

--- a/spec/compatibility/fill_in_spec.rb
+++ b/spec/compatibility/fill_in_spec.rb
@@ -125,17 +125,31 @@ RSpec.describe 'fill_in compatibility', sinatra: true do
     expect(find(:fillable_field, 'form_first_name').value).to eq('Harry')
   end
 
-  it 'fills number values with incomplete prefixes' do
+  it 'fills a negative number' do
     visit '/'
     track_form_amount_keys
+    fill_in('form_amount', with: '-7')
 
-    %w[-7 .5 1e3].each do |value|
-      fill_in('form_amount', with: value)
+    expect(find(:fillable_field, 'form_amount').value).to eq('-7')
+    expect(evaluate_script('window.capybara_formAmountKeydownEvents')).to eq %w[- 7]
+  end
 
-      expect(find(:fillable_field, 'form_amount').value).to eq(value)
-    end
+  it 'fills a number with a leading decimal point' do
+    visit '/'
+    track_form_amount_keys
+    fill_in('form_amount', with: '.5')
 
-    expect(evaluate_script('window.capybara_formAmountKeydownEvents')).to eq %w[- 7 . 5 1 e 3]
+    expect(find(:fillable_field, 'form_amount').value).to eq('.5')
+    expect(evaluate_script('window.capybara_formAmountKeydownEvents')).to eq %w[. 5]
+  end
+
+  it 'fills a number in exponent notation' do
+    visit '/'
+    track_form_amount_keys
+    fill_in('form_amount', with: '1e3')
+
+    expect(find(:fillable_field, 'form_amount').value).to eq('1e3')
+    expect(evaluate_script('window.capybara_formAmountKeydownEvents')).to eq %w[1 e 3]
   end
 
   it 'triggers onchange once' do

--- a/spec/compatibility/fill_in_spec.rb
+++ b/spec/compatibility/fill_in_spec.rb
@@ -17,6 +17,10 @@ FILL_IN_FORM_HTML = <<~HTML
         Date
         <input type="date" name="form[date]" id="form_date"/>
       </label>
+      <label for="form_amount">
+        Amount
+        <input type="number" name="form[amount]" id="form_amount"/>
+      </label>
     </form>
     <input type="text" name="with_change_event" value="default value" id="with_change_event"/>
     <input type="text" name="with_focus_event" value="" id="with_focus_event"/>
@@ -74,6 +78,15 @@ FILL_IN_HELPERS = Module.new do
     JS
     find(:css, 'h1', text: 'Form').click
   end
+
+  def track_form_amount_keys
+    find(:css, '#form_amount').execute_script <<~JS
+      window.capybara_formAmountKeydownEvents = [];
+      this.addEventListener('keydown', function(event) {
+        window.capybara_formAmountKeydownEvents.push(event.key);
+      });
+    JS
+  end
 end
 
 RSpec.describe 'fill_in compatibility', sinatra: true do
@@ -110,6 +123,19 @@ RSpec.describe 'fill_in compatibility', sinatra: true do
     fill_in('form_first_name', with: 'Harry', fill_options: { clear: :backspace })
 
     expect(find(:fillable_field, 'form_first_name').value).to eq('Harry')
+  end
+
+  it 'fills number values with incomplete prefixes' do
+    visit '/'
+    track_form_amount_keys
+
+    %w[-7 .5 1e3].each do |value|
+      fill_in('form_amount', with: value)
+
+      expect(find(:fillable_field, 'form_amount').value).to eq(value)
+    end
+
+    expect(evaluate_script('window.capybara_formAmountKeydownEvents')).to eq %w[- 7 . 5 1 e 3]
   end
 
   it 'triggers onchange once' do

--- a/spec/compatibility/node/set_spec.rb
+++ b/spec/compatibility/node/set_spec.rb
@@ -8,14 +8,18 @@ SET_TAB_KEY_HTML = <<~HTML
   <body>
     <label for="tag">Tag</label>
     <input id="tag" name="tag">
+    <label for="amount">Amount</label>
+    <input id="amount" name="amount" type="number">
     <div id="status">waiting</div>
     <script>
-      tag.addEventListener('keydown', function(event) {
-        if (event.key === 'Tab') {
-          event.preventDefault();
-          document.getElementById('status').textContent = 'tabbed:' + tag.value;
-          alert('tab was pressed');
-        }
+      [tag, amount].forEach(function(input) {
+        input.addEventListener('keydown', function(event) {
+          if (event.key === 'Tab') {
+            event.preventDefault();
+            document.getElementById('status').textContent = 'tabbed:' + input.value;
+            alert('tab was pressed');
+          }
+        });
       });
     </script>
   </body>
@@ -35,5 +39,17 @@ RSpec.describe 'Node#set compatibility', sinatra: true do
     expect(message).to eq('tab was pressed')
     expect(find('#status')).to have_text('tabbed:bad tag')
     expect(find('#tag').value).to eq('bad tag')
+  end
+
+  it 'presses Tab when setting a number input' do
+    visit '/tab-key'
+
+    message = accept_alert('tab was pressed', wait: 0.5) do
+      find('#amount').set("12\t")
+    end
+
+    expect(message).to eq('tab was pressed')
+    expect(find('#status')).to have_text('tabbed:12')
+    expect(find('#amount').value).to eq('12')
   end
 end


### PR DESCRIPTION
Fixes #149.

## Summary

- Replace non-empty number input values by selecting the existing text and typing the complete replacement.
- Preserve real key events without emitting an extra Delete event.
- Keep tab-separated input handling ahead of the number-specific path.
- Add independent compatibility examples for negative, leading-decimal, and exponent values, plus Tab key handling on number inputs.

## Root cause

The keyup compatibility path split values into a prefix passed to `fill()` and a final character passed to `type()`. Playwright validates number fields during `fill()`, so incomplete prefixes such as `-`, `.`, and `1e` failed before the final character could be typed.

## Validation

- Playwright compatibility specs: 18 examples, 0 failures, 1 existing pending
- Selenium compatibility specs: 18 examples, 0 failures
- `git diff --check`