### PR TITLE
Fix input handling when focus changes

### DIFF
--- a/lib/capybara/playwright/node.rb
+++ b/lib/capybara/playwright/node.rb
@@ -398,6 +398,9 @@ module Capybara
       end
 
       class TextInput < Settable
+        # Typing multi-kilobyte text can exceed Capybara's default wait time.
+        MAXIMUM_TYPED_TEXT_LENGTH = 1_000
+
         def set(value, **options)
           case options[:clear]
           when :backspace
@@ -440,11 +443,24 @@ module Capybara
             return
           end
 
-          if number_input? && !append
-            replace_number_text(text)
+          text = text.gsub(/\r\n?/, "\n")
+
+          if text.length > MAXIMUM_TYPED_TEXT_LENGTH
+            set_long_text(text, append: append)
             return
           end
 
+          if append
+            @element.type(text, timeout: @timeout) unless text.empty?
+          elsif text.empty?
+            @element.fill('', timeout: @timeout)
+          else
+            @element.select_text(timeout: @timeout)
+            @element.type(text, timeout: @timeout)
+          end
+        end
+
+        private def set_long_text(text, append:)
           grapheme_clusters = text.scan(/\X/)
           fill_text = grapheme_clusters[0...-1].join
           typed_text = grapheme_clusters[-1].to_s
@@ -455,20 +471,6 @@ module Capybara
             @element.fill(fill_text, timeout: @timeout)
           end
           @element.type(typed_text, timeout: @timeout) unless typed_text.empty?
-        end
-
-        private def number_input?
-          @element.evaluate('el => el.type === "number"')
-        end
-
-        private def replace_number_text(text)
-          if text.empty?
-            @element.fill('', timeout: @timeout)
-            return
-          end
-
-          @element.select_text(timeout: @timeout)
-          @element.type(text, timeout: @timeout)
         end
 
         private def type_tab_separated_text(text, append:)
@@ -757,8 +759,8 @@ module Capybara
           command: 'Meta',
         }
 
-        def initialize(element_or_keyboard, keys)
-          @element_or_keyboard = element_or_keyboard
+        def initialize(target, keys)
+          @target = target
 
           holding_keys = []
           @executables = keys.each_with_object([]) do |key, executables|
@@ -823,9 +825,44 @@ module Capybara
         end
 
         def execute
+          keyboard = keyboard_for_target
           @executables.each do |executable|
-            executable.execute_for(@element_or_keyboard)
+            executable.execute_for(keyboard)
           end
+        end
+
+        private def keyboard_for_target
+          return @target unless @target.is_a?(::Playwright::ElementHandle)
+
+          focus_for_typing
+          @target.owner_frame.page.keyboard
+        end
+
+        private def focus_for_typing
+          @target.evaluate(<<~JAVASCRIPT)
+            element => {
+              if (element.ownerDocument.activeElement === element) return;
+
+              element.focus();
+              if (element.isContentEditable) {
+                const selection = element.ownerDocument.getSelection();
+                const range = element.ownerDocument.createRange();
+                range.selectNodeContents(element);
+                range.collapse(false);
+                selection.removeAllRanges();
+                selection.addRange(range);
+                return;
+              }
+
+              if (typeof element.setSelectionRange === 'function') {
+                try {
+                  element.setSelectionRange(element.value.length, element.value.length);
+                } catch (error) {
+                  // Some input types expose setSelectionRange but do not support it.
+                }
+              }
+            }
+          JAVASCRIPT
         end
 
         class PressKey

--- a/spec/compatibility/fill_in_spec.rb
+++ b/spec/compatibility/fill_in_spec.rb
@@ -64,6 +64,62 @@ FILL_IN_KEYUP_TEXTAREA_HTML = <<~HTML
   </html>
 HTML
 
+FILL_IN_TOKEN_INPUT_HTML = <<~HTML
+  <!DOCTYPE html>
+  <html>
+  <body>
+    <label for="tags">Tags</label>
+    <input id="tags" name="tags">
+    <ul id="selected-tags"></ul>
+    <script>
+      const tags = document.getElementById('tags');
+      tags.addEventListener('input', function() {
+        const parts = this.value.split(',');
+        if (parts.length === 1) return;
+
+        parts.slice(0, -1).map(function(part) {
+          return part.trim();
+        }).filter(Boolean).forEach(function(tag) {
+          const item = document.createElement('li');
+          item.textContent = tag;
+          document.getElementById('selected-tags').appendChild(item);
+        });
+
+        this.value = parts.at(-1).trimStart();
+        this.blur();
+        this.focus();
+        this.setSelectionRange(0, 0);
+      });
+    </script>
+  </body>
+  </html>
+HTML
+
+FILL_IN_ONE_TIME_CODE_HTML = <<~HTML
+  <!DOCTYPE html>
+  <html>
+  <body>
+    <label for="digit-1">Verification code</label>
+    <div id="verification-code">
+      <input id="digit-1" maxlength="1" inputmode="numeric">
+      <input id="digit-2" maxlength="1" inputmode="numeric">
+      <input id="digit-3" maxlength="1" inputmode="numeric">
+      <input id="digit-4" maxlength="1" inputmode="numeric">
+      <input id="digit-5" maxlength="1" inputmode="numeric">
+      <input id="digit-6" maxlength="1" inputmode="numeric">
+    </div>
+    <script>
+      const digits = Array.from(document.querySelectorAll('#verification-code input'));
+      digits.forEach(function(input, index) {
+        input.addEventListener('input', function() {
+          if (this.value && digits[index + 1]) digits[index + 1].focus();
+        });
+      });
+    </script>
+  </body>
+  </html>
+HTML
+
 FILL_IN_EMOJI_TEXT = "a\u{1F600}cd\u{1F634} \u{1F6CC}\u{1F3FD}\u{1F1F5}\u{1F1F9} " \
                      "e\u{1F93E}\u{1F3FD}\u200D\u2640\uFE0Ff"
 
@@ -95,6 +151,8 @@ RSpec.describe 'fill_in compatibility', sinatra: true do
   before do
     sinatra.get('/') { FILL_IN_FORM_HTML }
     sinatra.get('/keyup') { FILL_IN_KEYUP_TEXTAREA_HTML }
+    sinatra.get('/token-input') { FILL_IN_TOKEN_INPUT_HTML }
+    sinatra.get('/one-time-code') { FILL_IN_ONE_TIME_CODE_HTML }
   end
 
   it 'triggers keyup events' do
@@ -104,6 +162,24 @@ RSpec.describe 'fill_in compatibility', sinatra: true do
 
     expect(find(:fillable_field, 'Body').value).to eq('updated FAQ')
     expect(find(:css, '#preview')).to have_text('updated FAQ')
+  end
+
+  it 'enters comma-separated tags in a token input' do
+    visit '/token-input'
+    fill_in 'Tags', with: 'tag1, tag2, tag3,'
+
+    expect(page).to have_css('#selected-tags li', count: 3)
+    expect(all('#selected-tags li').map(&:text)).to eq %w[tag1 tag2 tag3]
+    expect(find(:fillable_field, 'Tags').value).to eq('')
+  end
+
+  it 'enters a one-time code in auto-advancing inputs' do
+    visit '/one-time-code'
+    fill_in 'Verification code', with: '123456'
+
+    digits = all('#verification-code input').map(&:value)
+    expect(digits).to eq %w[1 2 3 4 5 6]
+    expect(page.active_element[:id]).to eq('digit-6')
   end
 
   it 'replaces an existing value' do

--- a/spec/compatibility/send_keys_spec.rb
+++ b/spec/compatibility/send_keys_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+CONTENTEDITABLE_MENTION_HTML = <<~HTML
+  <!DOCTYPE html>
+  <html>
+  <body>
+    <div id="editor" contenteditable="true" role="textbox" aria-label="Message">Hello</div>
+    <input id="mention-search" aria-label="Mention search">
+    <script>
+      const editor = document.getElementById('editor');
+      editor.addEventListener('input', function() {
+        if (window.mentionOpened || !this.textContent.includes('@')) return;
+
+        window.mentionOpened = true;
+        document.getElementById('mention-search').focus();
+      });
+    </script>
+  </body>
+  </html>
+HTML
+
+RSpec.describe 'send_keys compatibility', sinatra: true do
+  before { sinatra.get('/contenteditable-mention') { CONTENTEDITABLE_MENTION_HTML } }
+
+  it 'continues typing at the end of a contenteditable after an autocomplete takes focus' do
+    visit '/contenteditable-mention'
+    editor = find('#editor')
+    editor.click
+    editor.send_keys(:end)
+    editor.send_keys('@')
+    editor.send_keys('alice')
+
+    expect(editor.text).to eq('Hello@alice')
+  end
+end

--- a/spec/feature/example_spec.rb
+++ b/spec/feature/example_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe 'Example' do
       Capybara.app_host = 'https://github.com'
       visit '/'
 
-      expect_any_instance_of(Playwright::ElementHandle).to receive(:press).with('Shift+Home')
+      expect_any_instance_of(Playwright::Keyboard).to receive(:press).with('Shift+Home')
 
       find('body').send_keys %i[shift home]
     end


### PR DESCRIPTION
## Summary

Fixes #155 by making Playwright input behavior match Selenium in controls that react while typing or temporarily move focus.

- types ordinary-length fill values as one continuous user input sequence so per-character handlers can commit tokens or advance OTP fields
- keeps the existing fast path for multi-kilobyte values
- sends element keys through the page keyboard after focusing the target once, preserving focus changes caused by the page
- restores the caret to the end when a subsequent send_keys call targets an inactive input or contenteditable
- normalizes CRLF before typing to preserve textarea behavior

## Regression coverage

Adds Selenium-compatible cases for:

- comma-separated token inputs
- auto-advancing one-time-code inputs
- contenteditable mention editors whose autocomplete temporarily takes focus

## Verification

- Selenium: 3 new compatibility examples pass
- Playwright: 21 compatibility examples, 0 failures, 1 pre-existing pending example
- Capybara fill_in contract: 42 examples, 0 failures
- Capybara send_keys contract: 5 examples, 0 failures
- Feature specs excluding the external example spec: 32 examples, 0 failures
- External modifier example: 1 example, 0 failures

The PR remains Draft while the full browser and Ruby-version matrix runs in CI.
