### PR TITLE
Use Playwright keyboard semantics for reactive text input

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ end
 
 Refer the [documentation](https://playwright-ruby-client.vercel.app/docs/article/guides/rails_integration) for more detailed configuration.
 
+## Selenium compatibility
+
+This driver delegates keyboard focus and caret behavior to Playwright rather than overriding it with JavaScript. One
+observable difference is that when a `contenteditable` element loses focus between `send_keys` calls, Playwright may
+place the caret differently from Selenium when the element is focused again. Specify the caret movement explicitly
+when the test depends on it:
+
+```ruby
+editor.send_keys(:end, '@') # The page moves focus to an autocomplete control.
+editor.send_keys(:end, 'alice')
+```
+
+For large replacement values, `fill_in` uses Playwright's fast `fill` action and therefore does not emit per-character
+keyboard events.
+
 ## Development
 
 Prepare to run tests:

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ editor.send_keys(:end, '@') # The page moves focus to an autocomplete control.
 editor.send_keys(:end, 'alice')
 ```
 
+For text inputs and textareas, `fill_in` sends keyboard events for every character regardless of the value length. This
+preserves reactive input behavior, but filling very large values is slower than Playwright's event-free `fill` action.
+
 ## Development
 
 Prepare to run tests:

--- a/README.md
+++ b/README.md
@@ -56,9 +56,6 @@ editor.send_keys(:end, '@') # The page moves focus to an autocomplete control.
 editor.send_keys(:end, 'alice')
 ```
 
-For large replacement values, `fill_in` uses Playwright's fast `fill` action and therefore does not emit per-character
-keyboard events.
-
 ## Development
 
 Prepare to run tests:

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ editor.send_keys(:end, 'alice')
 
 For text inputs and textareas, `fill_in` sends keyboard events for every character regardless of the value length. This
 preserves reactive input behavior, but filling very large values is slower than Playwright's event-free `fill` action.
+When input speed matters more than per-character keyboard events, consider using Playwright's native `fill` directly:
+
+```ruby
+page.driver.with_playwright_page { |playwright_page| playwright_page.get_by_label('Body').fill(large_value) }
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,12 @@ editor.send_keys(:end, '@') # The page moves focus to an autocomplete control.
 editor.send_keys(:end, 'alice')
 ```
 
-For text inputs and textareas, `fill_in` sends keyboard events for every character regardless of the value length. This
-preserves reactive input behavior, but filling very large values is slower than Playwright's event-free `fill` action.
-When input speed matters more than per-character keyboard events, consider using Playwright's native `fill` directly:
+For text inputs and textareas, `fill_in` uses Playwright's typing behavior for every character regardless of the value
+length. Playwright sends `keydown`, `keypress`/`input`, and `keyup` for characters on a US keyboard, but sends only
+`input` for other characters, including Japanese text. This follows
+[Playwright's documented keyboard behavior](https://playwright.dev/docs/api/class-keyboard#keyboard-type). Typing very
+large values is slower than Playwright's native `fill`, which does not send per-character keyboard events. When input
+speed matters more than those events, consider using `fill` directly:
 
 ```ruby
 page.driver.with_playwright_page { |playwright_page| playwright_page.get_by_label('Body').fill(large_value) }

--- a/lib/capybara/playwright/node.rb
+++ b/lib/capybara/playwright/node.rb
@@ -398,6 +398,9 @@ module Capybara
       end
 
       class TextInput < Settable
+        # Typing multi-kilobyte text can exceed Capybara's default wait time.
+        MAXIMUM_TYPED_TEXT_LENGTH = 1_000
+
         def set(value, **options)
           case options[:clear]
           when :backspace
@@ -435,40 +438,37 @@ module Capybara
             return
           end
 
+          text = text.gsub(/\r\n?/, "\n")
+
           if text.include?("\t")
             type_tab_separated_text(text, append: append)
             return
           end
 
-          if number_input? && !append
-            replace_number_text(text)
+          if !append && text.length > MAXIMUM_TYPED_TEXT_LENGTH
+            @element.fill(text, timeout: @timeout)
             return
           end
 
-          grapheme_clusters = text.scan(/\X/)
-          fill_text = grapheme_clusters[0...-1].join
-          typed_text = grapheme_clusters[-1].to_s
-
+          keyboard = @element.owner_frame.page.keyboard
           if append
-            @element.type(fill_text, timeout: @timeout) unless fill_text.empty?
-          else
-            @element.fill(fill_text, timeout: @timeout)
-          end
-          @element.type(typed_text, timeout: @timeout) unless typed_text.empty?
-        end
-
-        private def number_input?
-          @element.evaluate('el => el.type === "number"')
-        end
-
-        private def replace_number_text(text)
-          if text.empty?
+            type_text(keyboard, text)
+          elsif text.empty?
             @element.fill('', timeout: @timeout)
-            return
+          else
+            @element.select_text(timeout: @timeout)
+            type_text(keyboard, text)
           end
+        end
 
-          @element.select_text(timeout: @timeout)
-          @element.type(text, timeout: @timeout)
+        private def type_text(keyboard, text)
+          head, *tail = text.split("\n", -1)
+          keyboard.type(head) unless head.empty?
+
+          tail.each do |part|
+            keyboard.press('Enter')
+            keyboard.type(part) unless part.empty?
+          end
         end
 
         private def type_tab_separated_text(text, append:)
@@ -478,7 +478,7 @@ module Capybara
 
           tail.each do |part|
             keyboard.press('Tab')
-            keyboard.type(part) unless part.empty?
+            type_text(keyboard, part.gsub(/\r\n?/, "\n"))
           end
         end
       end

--- a/lib/capybara/playwright/node.rb
+++ b/lib/capybara/playwright/node.rb
@@ -462,6 +462,8 @@ module Capybara
         end
 
         private def type_text(keyboard, text)
+          return if text.empty?
+
           head, *tail = text.split("\n", -1)
           keyboard.type(head) unless head.empty?
 

--- a/lib/capybara/playwright/node.rb
+++ b/lib/capybara/playwright/node.rb
@@ -398,9 +398,6 @@ module Capybara
       end
 
       class TextInput < Settable
-        # Typing multi-kilobyte text can exceed Capybara's default wait time.
-        MAXIMUM_TYPED_TEXT_LENGTH = 1_000
-
         def set(value, **options)
           case options[:clear]
           when :backspace
@@ -442,11 +439,6 @@ module Capybara
 
           if text.include?("\t")
             type_tab_separated_text(text, append: append)
-            return
-          end
-
-          if !append && text.length > MAXIMUM_TYPED_TEXT_LENGTH
-            @element.fill(text, timeout: @timeout)
             return
           end
 

--- a/lib/capybara/playwright/node.rb
+++ b/lib/capybara/playwright/node.rb
@@ -408,6 +408,7 @@ module Capybara
             existing_text.length.times { @element.press('Backspace', timeout: @timeout) }
           when :none
             @element.press('End', timeout: @timeout)
+            ensure_attached
           when Array
             @internal_logger.warn "options { clear: #{options[:clear]} } is ignored"
           end
@@ -462,6 +463,7 @@ module Capybara
           else
             first_character = head[/\A\X/]
             @element.type(first_character, timeout: @timeout)
+            ensure_attached
             remaining_text = head[first_character.length..-1]
             keyboard.type(remaining_text) unless remaining_text.empty?
           end
@@ -497,6 +499,11 @@ module Capybara
             end
             type_text(keyboard, part.gsub(/\r\n?/, "\n"))
           end
+        end
+
+        private def ensure_attached
+          # Trigger Playwright's stale-element check without changing focus.
+          @element.enabled?
         end
       end
 

--- a/lib/capybara/playwright/node.rb
+++ b/lib/capybara/playwright/node.rb
@@ -368,7 +368,9 @@ module Capybara
             end
           end
 
-        settable_class.new(@element, capybara_default_wait_time, @internal_logger).set(value, **options)
+        assert_element_not_stale do
+          settable_class.new(@element, capybara_default_wait_time, @internal_logger).set(value, **options)
+        end
       rescue ::Playwright::TimeoutError => err
         raise NotActionableError.new(err)
       end
@@ -417,18 +419,17 @@ module Capybara
             text = text[0...-1]
           end
 
-          set_text(text, append: options[:clear] == :none)
+          keyboard = @element.owner_frame.page.keyboard
+          set_text(text, append: options[:clear] == :none, keyboard: keyboard)
 
-          if press_enter
-            @element.press('Enter', timeout: @timeout)
-          end
+          keyboard.press('Enter') if press_enter
         rescue ::Playwright::TimeoutError
           raise if @element.editable?
 
           @internal_logger.info("Node#set: element is not editable. #{@element}")
         end
 
-        private def set_text(text, append:)
+        private def set_text(text, append:, keyboard:)
           # ElementHandle#type can refocus inherited contenteditable descendants and drop the input.
           if @element.evaluate('el => el.isContentEditable') && !append
             @element.fill(text, timeout: @timeout)
@@ -438,19 +439,34 @@ module Capybara
           text = text.gsub(/\r\n?/, "\n")
 
           if text.include?("\t")
-            type_tab_separated_text(text, append: append)
+            type_tab_separated_text(text, append: append, keyboard: keyboard)
             return
           end
 
-          keyboard = @element.owner_frame.page.keyboard
           if append
             type_text(keyboard, text)
           elsif text.empty?
             @element.fill('', timeout: @timeout)
           else
             @element.select_text(timeout: @timeout)
-            type_text(keyboard, text)
+            replace_text(keyboard, text)
           end
+        end
+
+        private def replace_text(keyboard, text)
+          head, *tail = text.split("\n", -1)
+          if head.empty?
+            @element.press('Enter', timeout: @timeout)
+            head = tail.shift
+            keyboard.type(head) unless head.empty?
+          else
+            first_character = head[/\A\X/]
+            @element.type(first_character, timeout: @timeout)
+            remaining_text = head[first_character.length..-1]
+            keyboard.type(remaining_text) unless remaining_text.empty?
+          end
+
+          type_lines(keyboard, tail)
         end
 
         private def type_text(keyboard, text)
@@ -459,19 +475,26 @@ module Capybara
           head, *tail = text.split("\n", -1)
           keyboard.type(head) unless head.empty?
 
-          tail.each do |part|
+          type_lines(keyboard, tail)
+        end
+
+        private def type_lines(keyboard, parts)
+          parts.each do |part|
             keyboard.press('Enter')
             keyboard.type(part) unless part.empty?
           end
         end
 
-        private def type_tab_separated_text(text, append:)
+        private def type_tab_separated_text(text, append:, keyboard:)
           head, *tail = text.split("\t", -1)
-          set_text(head, append: append)
-          keyboard = @element.owner_frame.page.keyboard
+          set_text(head, append: append, keyboard: keyboard)
 
-          tail.each do |part|
-            keyboard.press('Tab')
+          tail.each_with_index do |part, index|
+            if index.zero? && !append && head.empty?
+              @element.press('Tab', timeout: @timeout)
+            else
+              keyboard.press('Tab')
+            end
             type_text(keyboard, part.gsub(/\r\n?/, "\n"))
           end
         end

--- a/spec/capybara/playwright_spec.rb
+++ b/spec/capybara/playwright_spec.rb
@@ -16,6 +16,8 @@ Capybara::SpecHelper.run_specs TestSessions::Playwright, 'Playwright' do |exampl
   end
 
   case example.metadata[:full_description]
+  when /should fill in a textarea in a reasonable time by default/
+    pending 'fill_in intentionally sends per-character keyboard events'
   when /should offset outside (the|from center of) element/
     pending 'Playwright does not allow to click outside the element'
   when /should not retry clicking when wait is disabled/

--- a/spec/compatibility/fill_in_spec.rb
+++ b/spec/compatibility/fill_in_spec.rb
@@ -64,6 +64,62 @@ FILL_IN_KEYUP_TEXTAREA_HTML = <<~HTML
   </html>
 HTML
 
+FILL_IN_TOKEN_INPUT_HTML = <<~HTML
+  <!DOCTYPE html>
+  <html>
+  <body>
+    <label for="tags">Tags</label>
+    <input id="tags" name="tags">
+    <ul id="selected-tags"></ul>
+    <script>
+      const tags = document.getElementById('tags');
+      tags.addEventListener('input', function() {
+        const parts = this.value.split(',');
+        if (parts.length === 1) return;
+
+        parts.slice(0, -1).map(function(part) {
+          return part.trim();
+        }).filter(Boolean).forEach(function(tag) {
+          const item = document.createElement('li');
+          item.textContent = tag;
+          document.getElementById('selected-tags').appendChild(item);
+        });
+
+        this.value = parts.at(-1).trimStart();
+        this.blur();
+        this.focus();
+        this.setSelectionRange(0, 0);
+      });
+    </script>
+  </body>
+  </html>
+HTML
+
+FILL_IN_ONE_TIME_CODE_HTML = <<~HTML
+  <!DOCTYPE html>
+  <html>
+  <body>
+    <label for="digit-1">Verification code</label>
+    <div id="verification-code">
+      <input id="digit-1" maxlength="1" inputmode="numeric">
+      <input id="digit-2" maxlength="1" inputmode="numeric">
+      <input id="digit-3" maxlength="1" inputmode="numeric">
+      <input id="digit-4" maxlength="1" inputmode="numeric">
+      <input id="digit-5" maxlength="1" inputmode="numeric">
+      <input id="digit-6" maxlength="1" inputmode="numeric">
+    </div>
+    <script>
+      const digits = Array.from(document.querySelectorAll('#verification-code input'));
+      digits.forEach(function(input, index) {
+        input.addEventListener('input', function() {
+          if (this.value && digits[index + 1]) digits[index + 1].focus();
+        });
+      });
+    </script>
+  </body>
+  </html>
+HTML
+
 FILL_IN_EMOJI_TEXT = "a\u{1F600}cd\u{1F634} \u{1F6CC}\u{1F3FD}\u{1F1F5}\u{1F1F9} " \
                      "e\u{1F93E}\u{1F3FD}\u200D\u2640\uFE0Ff"
 
@@ -95,6 +151,8 @@ RSpec.describe 'fill_in compatibility', sinatra: true do
   before do
     sinatra.get('/') { FILL_IN_FORM_HTML }
     sinatra.get('/keyup') { FILL_IN_KEYUP_TEXTAREA_HTML }
+    sinatra.get('/token-input') { FILL_IN_TOKEN_INPUT_HTML }
+    sinatra.get('/one-time-code') { FILL_IN_ONE_TIME_CODE_HTML }
   end
 
   it 'triggers keyup events' do
@@ -104,6 +162,24 @@ RSpec.describe 'fill_in compatibility', sinatra: true do
 
     expect(find(:fillable_field, 'Body').value).to eq('updated FAQ')
     expect(find(:css, '#preview')).to have_text('updated FAQ')
+  end
+
+  it 'enters comma-separated tags in a token input' do
+    visit '/token-input'
+    fill_in 'Tags', with: 'tag1, tag2, tag3,'
+
+    expect(page).to have_css('#selected-tags li', count: 3)
+    expect(all('#selected-tags li').map(&:text)).to eq %w[tag1 tag2 tag3]
+    expect(find(:fillable_field, 'Tags').value).to eq('')
+  end
+
+  it 'enters a one-time code in auto-advancing inputs' do
+    visit '/one-time-code'
+    fill_in 'Verification code', with: '123456'
+
+    digits = all('#verification-code input').map(&:value)
+    expect(digits).to eq %w[1 2 3 4 5 6]
+    expect(page.active_element[:id]).to eq('digit-6')
   end
 
   it 'replaces an existing value' do

--- a/spec/compatibility/fill_in_spec.rb
+++ b/spec/compatibility/fill_in_spec.rb
@@ -115,6 +115,10 @@ FILL_IN_ONE_TIME_CODE_HTML = <<~HTML
           if (this.value && digits[index + 1]) digits[index + 1].focus();
         });
       });
+
+      document.addEventListener('keydown', function(event) {
+        if (event.key === 'Enter') window.enterTarget = event.target.id;
+      });
     </script>
   </body>
   </html>
@@ -180,6 +184,15 @@ RSpec.describe 'fill_in compatibility', sinatra: true do
     digits = all('#verification-code input').map(&:value)
     expect(digits).to eq %w[1 2 3 4 5 6]
     expect(page.active_element[:id]).to eq('digit-6')
+  end
+
+  it 'sends a trailing Enter to the current auto-advanced input' do
+    visit '/one-time-code'
+    fill_in 'Verification code', with: "123456\n"
+
+    digits = all('#verification-code input').map(&:value)
+    expect(digits).to eq %w[1 2 3 4 5 6]
+    expect(evaluate_script('window.enterTarget')).to eq('digit-6')
   end
 
   it 'replaces an existing value' do

--- a/spec/feature/fill_in_spec.rb
+++ b/spec/feature/fill_in_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+FILL_IN_LONG_TEXT_HTML = <<~HTML
+  <!DOCTYPE html>
+  <html>
+  <body>
+    <label for="body">Body</label>
+    <textarea id="body" name="body" data-keyup-count="0"></textarea>
+    <script>
+      const body = document.getElementById('body');
+      body.addEventListener('keyup', function() {
+        body.dataset.keyupCount = String(Number(body.dataset.keyupCount) + 1);
+      });
+    </script>
+  </body>
+  </html>
+HTML
+
+RSpec.describe '#fill_in', sinatra: true do
+  before { sinatra.get('/long-text') { FILL_IN_LONG_TEXT_HTML } }
+
+  it 'types replacement values longer than 1000 characters' do
+    visit '/long-text'
+    long_text = 'a' * 1_001
+
+    fill_in 'Body', with: long_text
+
+    textarea = find(:fillable_field, 'Body')
+    expect(textarea.value).to eq(long_text)
+    expect(textarea['data-keyup-count']).to eq(long_text.length.to_s)
+  end
+end

--- a/spec/feature/fill_in_spec.rb
+++ b/spec/feature/fill_in_spec.rb
@@ -7,9 +7,12 @@ FILL_IN_LONG_TEXT_HTML = <<~HTML
   <html>
   <body>
     <label for="body">Body</label>
-    <textarea id="body" name="body" data-keyup-count="0"></textarea>
+    <textarea id="body" name="body" data-input-count="0" data-keyup-count="0"></textarea>
     <script>
       const body = document.getElementById('body');
+      body.addEventListener('input', function() {
+        body.dataset.inputCount = String(Number(body.dataset.inputCount) + 1);
+      });
       body.addEventListener('keyup', function() {
         body.dataset.keyupCount = String(Number(body.dataset.keyupCount) + 1);
       });
@@ -30,5 +33,17 @@ RSpec.describe '#fill_in', sinatra: true do
     textarea = find(:fillable_field, 'Body')
     expect(textarea.value).to eq(long_text)
     expect(textarea['data-keyup-count']).to eq(long_text.length.to_s)
+  end
+
+  it 'uses input events without keyup for non-US keyboard characters' do
+    visit '/long-text'
+    text = '更新済み'
+
+    fill_in 'Body', with: text
+
+    textarea = find(:fillable_field, 'Body')
+    expect(textarea.value).to eq(text)
+    expect(textarea['data-input-count']).to eq(text.length.to_s)
+    expect(textarea['data-keyup-count']).to eq('0')
   end
 end

--- a/spec/feature/send_keys_spec.rb
+++ b/spec/feature/send_keys_spec.rb
@@ -2,6 +2,25 @@
 
 require 'spec_helper'
 
+SEND_KEYS_CONTENTEDITABLE_MENTION_HTML = <<~HTML
+  <!DOCTYPE html>
+  <html>
+  <body>
+    <div id="editor" contenteditable="true">Hello</div>
+    <input id="mention-search">
+    <script>
+      const editor = document.getElementById('editor');
+      editor.addEventListener('input', function() {
+        if (window.mentionOpened || !this.textContent.includes('@')) return;
+
+        window.mentionOpened = true;
+        document.getElementById('mention-search').focus();
+      });
+    </script>
+  </body>
+  </html>
+HTML
+
 RSpec.describe '#send_keys', sinatra: true do
   before do
     skip if Gem::Version.new(Capybara::VERSION) < Gem::Version.new('3.36.0')
@@ -16,6 +35,8 @@ RSpec.describe '#send_keys', sinatra: true do
         </html>
       HTML
     end
+
+    sinatra.get('/contenteditable-mention') { SEND_KEYS_CONTENTEDITABLE_MENTION_HTML }
   end
 
   it 'defaults to sending keys to the active_element' do
@@ -26,5 +47,18 @@ RSpec.describe '#send_keys', sinatra: true do
     page.send_keys(:tab)
 
     expect(page.active_element).to match_selector(:css, '[tabindex="1"]')
+  end
+
+  it 'allows the caret position to be explicit after a contenteditable loses focus' do
+    visit '/contenteditable-mention'
+    editor = find('#editor')
+    editor.send_keys(:end)
+    editor.send_keys('@')
+
+    expect(page.active_element[:id]).to eq('mention-search')
+
+    editor.send_keys(:end, 'alice')
+
+    expect(editor.text).to eq('Hello@alice')
   end
 end

--- a/spec/feature/stale_element_spec.rb
+++ b/spec/feature/stale_element_spec.rb
@@ -49,4 +49,28 @@ RSpec.describe 'stale element handling' do
       expect(el.inspect).to eq('Obsolete #<Capybara::Node::Element>')
     end
   end
+
+  it 'retries filling when the selected input is replaced before typing' do
+    page.driver.with_playwright_page do |page|
+      page.content = <<~HTML
+        <label for="field">Field</label>
+        <input id="field">
+        <script>
+          const field = document.getElementById('field');
+          field.addEventListener('focus', function() {
+            if (window.replacementScheduled) return;
+
+            window.replacementScheduled = true;
+            queueMicrotask(function() {
+              field.replaceWith(field.cloneNode(true));
+            });
+          });
+        </script>
+      HTML
+    end
+
+    fill_in 'Field', with: 'abc'
+
+    expect(find('#field').value).to eq('abc')
+  end
 end

--- a/spec/feature/stale_element_spec.rb
+++ b/spec/feature/stale_element_spec.rb
@@ -73,4 +73,56 @@ RSpec.describe 'stale element handling' do
 
     expect(find('#field').value).to eq('abc')
   end
+
+  it 'retries appending when the input is replaced after focusing' do
+    page.driver.with_playwright_page do |page|
+      page.content = <<~HTML
+        <label for="field">Field</label>
+        <input id="field" value="seed">
+        <script>
+          const field = document.getElementById('field');
+          field.addEventListener('focus', function() {
+            if (window.replacementScheduled) return;
+
+            window.replacementScheduled = true;
+            queueMicrotask(function() {
+              const replacement = field.cloneNode(true);
+              replacement.value = field.value;
+              field.replaceWith(replacement);
+            });
+          });
+        </script>
+      HTML
+    end
+
+    fill_in 'Field', with: 'abc', fill_options: { clear: :none }
+
+    expect(find('#field').value).to eq('seedabc')
+  end
+
+  it 'retries filling when the input is replaced after the first character' do
+    page.driver.with_playwright_page do |page|
+      page.content = <<~HTML
+        <label for="field">Field</label>
+        <input id="field">
+        <script>
+          const field = document.getElementById('field');
+          field.addEventListener('input', function() {
+            if (window.replacementScheduled) return;
+
+            window.replacementScheduled = true;
+            queueMicrotask(function() {
+              const replacement = field.cloneNode(true);
+              replacement.value = field.value;
+              field.replaceWith(replacement);
+            });
+          });
+        </script>
+      HTML
+    end
+
+    fill_in 'Field', with: 'abc'
+
+    expect(find('#field').value).to eq('abc')
+  end
 end


### PR DESCRIPTION
## Summary

Addresses the reactive `fill_in` failure reported in #155 while preserving the key events supported by Playwright for #98.

- replaces `fill(prefix) + type(last_character)` with a continuous Playwright typing sequence for replacement and appended values, including values longer than 1,000 characters
- keeps the initial text entry element-bound, then verifies that the selected handle is still attached before handing the remainder to the page keyboard
- retries through Capybara when a reactive UI replaces the input after focus or after the first character
- preserves focus changes for token inputs, auto-advancing OTP controls, trailing Enter, CRLF, and tab-separated input
- keeps empty-value and contenteditable replacement on the existing Playwright `fill` path
- leaves `send_keys` on Playwright native element behavior without JavaScript-based focus or caret management

## Intentional Playwright differences

### Contenteditable caret placement

When a contenteditable loses focus between `send_keys` calls, Playwright and Selenium can place the caret differently when the element is targeted again. The README documents this difference and shows how to make caret movement explicit with `send_keys(:end, ...)`.

### Non-US keyboard characters

Playwright emits `keydown`, `keypress`/`input`, and `keyup` for characters on a US keyboard, but emits only `input` for other characters such as Japanese text. This PR follows that native Playwright behavior instead of synthesizing keyboard events with JavaScript. The README documents the boundary explicitly.

### Large values

Unlike Selenium optimized handling for long values, `fill_in` deliberately uses Playwright typing behavior for every character regardless of length. The README documents the performance tradeoff and shows how to call Playwright native `fill` directly when speed matters more than per-character events.

## Regression coverage

- ASCII keyup-driven textareas and a 1,001-character replacement value
- non-US keyboard input behavior
- comma-separated token inputs
- auto-advancing one-time-code inputs and trailing Enter
- reactive replacement after focus and after the first character, including `clear: :none`
- CRLF and tab-separated text input
- explicit caret positioning after a contenteditable autocomplete moves focus

## Verification

- focused Playwright stale/fill/compatibility specs: 28 examples, 0 failures, 1 existing pending example
- Selenium compatibility fill/set specs: 21 examples, 0 failures, 1 existing pending example
- Capybara upstream `fill_in` specs: 42 examples, 0 failures, 1 intentional performance pending example
- Ruby 2.4 through 4.0 example jobs: passing
- Selenium/Playwright compatibility job: passing
- Chromium, Firefox, and WebKit full driver jobs: passing
- latest GitHub Actions run: all 14 checks passing

Supersedes #158.