### PR TITLE
Retry stale Playwright actions while preserving auto-waiting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,11 @@ end
 - Prefer concise Ruby that reads top-to-bottom without carrying unnecessary temporary state.
 - Prefer small private helper objects only when they reduce complexity. Once extracted, give them Ruby-like method names and keep their public surface minimal.
 
+## Test Style
+- Avoid assertion roulette. Each example must verify one clearly named behavior so a failure identifies the broken behavior directly.
+- Do not use loops, parameter tables, or metaprogramming to generate examples for distinct public operations. Write an explicit `it` block for each operation, even when their setup and expectations are similar.
+- Split independent expectations into separate examples. Keep multiple expectations together only when they jointly describe one inseparable outcome.
+
 ## How to execute RSpec or Ruby
 
 `ruby` uses macOS system ruby interpreter (typically 2.6 or older). rbenv should be used.

--- a/lib/capybara/playwright/node.rb
+++ b/lib/capybara/playwright/node.rb
@@ -956,7 +956,7 @@ module Capybara
         def execute
           input_started = false
           mouse_down = false
-          @target.scroll_into_view_if_needed(timeout: @timeout)
+          @target.wait_for_element_state('visible', timeout: @timeout)
           @source.scroll_into_view_if_needed(timeout: @timeout)
 
           position_from = center_of(@source)

--- a/lib/capybara/playwright/node.rb
+++ b/lib/capybara/playwright/node.rb
@@ -956,6 +956,7 @@ module Capybara
         def execute
           input_started = false
           mouse_down = false
+          @target.scroll_into_view_if_needed(timeout: @timeout)
           @source.scroll_into_view_if_needed(timeout: @timeout)
 
           position_from = center_of(@source)

--- a/lib/capybara/playwright/node.rb
+++ b/lib/capybara/playwright/node.rb
@@ -5,6 +5,7 @@ module Capybara
       if options[:wait].is_a?(Numeric)
         options[:_playwright_wait] = options[:wait]
       end
+      options[:wait] = 0 if options[:wait] == false
 
       # Playwright waits for actionability while Capybara retries replaced elements.
       super
@@ -276,6 +277,21 @@ module Capybara
 
       class NotActionableError < StandardError ; end
       class StaleReferenceError < StandardError ; end
+      class MissingBoundingBoxError < StandardError ; end
+      class DragInterruptedError < StandardError ; end
+
+      class ElementGeometry
+        def self.bounding_box(element)
+          box = element.bounding_box
+          return box if box
+
+          unless element.evaluate('element => element.isConnected')
+            raise StaleReferenceError, 'Element is not attached to the DOM'
+          end
+
+          raise MissingBoundingBoxError, 'Element is attached but has no bounding box'
+        end
+      end
 
       def all_text
         assert_element_not_stale {
@@ -715,8 +731,7 @@ module Capybara
 
         private def position
           if @offset_center
-            box = @element.bounding_box
-            raise StaleReferenceError, 'Element has no bounding box' unless box
+            box = ElementGeometry.bounding_box(@element)
 
             {
               x: @coords[:x] + box['width'] / 2,
@@ -939,14 +954,16 @@ module Capybara
         end
 
         def execute
+          input_started = false
           mouse_down = false
           @source.scroll_into_view_if_needed(timeout: @timeout)
 
-          # down
           position_from = center_of(@source)
+          center_of(@target)
           @page.mouse.move(*position_from)
-          @page.mouse.down
+          input_started = true
           mouse_down = true
+          @page.mouse.down
 
           @target.scroll_into_view_if_needed(timeout: @timeout)
 
@@ -960,14 +977,17 @@ module Capybara
             mouse_down = false
           end
           sleep_delay
+        rescue StaleReferenceError, ::Playwright::Error => err
+          raise DragInterruptedError, "Drag was interrupted after input began: #{err.message}" if input_started
+
+          raise
         ensure
           @page.mouse.up if mouse_down
         end
 
         # @param element [Playwright::ElementHandle]
         private def center_of(element)
-          box = element.bounding_box
-          raise StaleReferenceError, 'Element has no bounding box' unless box
+          box = ElementGeometry.bounding_box(element)
 
           [box["x"] + box["width"] / 2, box["y"] + box["height"] / 2]
         end

--- a/lib/capybara/playwright/node.rb
+++ b/lib/capybara/playwright/node.rb
@@ -1,11 +1,13 @@
 module Capybara
   module ElementClickOptionPatch
     def perform_click_action(keys, **options)
+      return super unless driver.is_a?(Capybara::Playwright::Driver)
+
+      wait = options[:wait]
+
       # Expose `wait` value to the block given to perform_click_action.
-      if options[:wait].is_a?(Numeric)
-        options[:_playwright_wait] = options[:wait]
-      end
-      options[:wait] = 0 if options[:wait] == false
+      options[:_playwright_wait] = wait if wait.is_a?(Numeric)
+      options[:wait] = 0 if wait == false
 
       # Playwright waits for actionability while Capybara retries replaced elements.
       super

--- a/lib/capybara/playwright/node.rb
+++ b/lib/capybara/playwright/node.rb
@@ -6,16 +6,29 @@ module Capybara
         options[:_playwright_wait] = options[:wait]
       end
 
-      # Playwright has own auto-waiting feature.
-      # So disable Capybara's retry logic.
-      if driver.is_a?(Capybara::Playwright::Driver)
-        options[:wait] = 0
-      end
-
+      # Playwright waits for actionability while Capybara retries replaced elements.
       super
     end
   end
   Node::Element.prepend(ElementClickOptionPatch)
+
+  module ElementDragToPatch
+    def drag_to(target, **options)
+      return super unless driver.is_a?(Capybara::Playwright::Driver)
+
+      synchronize do
+        begin
+          base.drag_to(target.base, **options)
+        rescue Capybara::Playwright::Node::StaleReferenceError
+          # Capybara's synchronize reloads only the source element.
+          target.reload if session_options.automatic_reload
+          raise
+        end
+      end
+      self
+    end
+  end
+  Node::Element.prepend(ElementDragToPatch)
 
   module WithElementHandlePatch
     def with_playwright_element_handle(&block)
@@ -613,20 +626,26 @@ module Capybara
       end
 
       def click(keys = [], **options)
-        click_options = ClickOptions.new(@element, keys, options, capybara_default_wait_time)
-        @element.click(**click_options.as_params)
+        assert_element_not_stale do
+          click_options = ClickOptions.new(@element, keys, options, capybara_default_wait_time)
+          @element.click(**click_options.as_params)
+        end
       end
 
       def right_click(keys = [], **options)
-        click_options = ClickOptions.new(@element, keys, options, capybara_default_wait_time)
-        params = click_options.as_params
-        params[:button] = 'right'
-        @element.click(**params)
+        assert_element_not_stale do
+          click_options = ClickOptions.new(@element, keys, options, capybara_default_wait_time)
+          params = click_options.as_params
+          params[:button] = 'right'
+          @element.click(**params)
+        end
       end
 
       def double_click(keys = [], **options)
-        click_options = ClickOptions.new(@element, keys, options, capybara_default_wait_time)
-        @element.dblclick(**click_options.as_params)
+        assert_element_not_stale do
+          click_options = ClickOptions.new(@element, keys, options, capybara_default_wait_time)
+          @element.dblclick(**click_options.as_params)
+        end
       end
 
       class ClickOptions
@@ -697,6 +716,7 @@ module Capybara
         private def position
           if @offset_center
             box = @element.bounding_box
+            raise StaleReferenceError, 'Element has no bounding box' unless box
 
             {
               x: @coords[:x] + box['width'] / 2,
@@ -883,11 +903,17 @@ module Capybara
       end
 
       def hover
-        @element.hover(timeout: capybara_default_wait_time)
+        assert_element_not_stale do
+          @element.hover(timeout: capybara_default_wait_time)
+        end
       end
 
-      def drag_to(element, **options)
-        DragTo.new(@page, @element, element.element, options).execute
+      def drag_to(target, **options)
+        assert_element_not_stale do
+          target.send(:assert_element_not_stale) do
+            DragTo.new(@page, @element, target.element, options, capybara_default_wait_time).execute
+          end
+        end
       end
 
       class DragTo
@@ -904,22 +930,25 @@ module Capybara
         # @param page [Playwright::Page]
         # @param source [Playwright::ElementHandle]
         # @param target [Playwright::ElementHandle]
-        def initialize(page, source, target, options)
+        def initialize(page, source, target, options, timeout)
           @page = page
           @source = source
           @target = target
           @options = options
+          @timeout = timeout
         end
 
         def execute
-          @source.scroll_into_view_if_needed
+          mouse_down = false
+          @source.scroll_into_view_if_needed(timeout: @timeout)
 
           # down
           position_from = center_of(@source)
           @page.mouse.move(*position_from)
           @page.mouse.down
+          mouse_down = true
 
-          @target.scroll_into_view_if_needed
+          @target.scroll_into_view_if_needed(timeout: @timeout)
 
           # move and up
           sleep_delay
@@ -928,20 +957,30 @@ module Capybara
             @page.mouse.move(*position_to, steps: 6)
             sleep_delay
             @page.mouse.up
+            mouse_down = false
           end
           sleep_delay
+        ensure
+          @page.mouse.up if mouse_down
         end
 
         # @param element [Playwright::ElementHandle]
         private def center_of(element)
           box = element.bounding_box
+          raise StaleReferenceError, 'Element has no bounding box' unless box
+
           [box["x"] + box["width"] / 2, box["y"] + box["height"] / 2]
         end
 
-        private def with_key_pressing(keys, &block)
-          keys.each { |key| @page.keyboard.down(key) }
-          block.call
-          keys.each { |key| @page.keyboard.up(key) }
+        private def with_key_pressing(keys)
+          pressed_keys = []
+          keys.each do |key|
+            @page.keyboard.down(key)
+            pressed_keys << key
+          end
+          yield
+        ensure
+          pressed_keys.reverse_each { |key| @page.keyboard.up(key) }
         end
 
         # @returns Array<String>
@@ -1121,7 +1160,9 @@ module Capybara
       end
 
       def obscured?
-        @element.capybara_obscured?
+        assert_element_not_stale do
+          @element.capybara_obscured?
+        end
       end
 
       def checked?

--- a/spec/feature/click_wait_spec.rb
+++ b/spec/feature/click_wait_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+RSpec.describe 'click wait options' do
+  it 'passes a numeric wait to the Playwright action' do
+    visit 'about:blank'
+    page.driver.with_playwright_page do |playwright_page|
+      playwright_page.content = '<button id="button">Click</button>'
+    end
+    playwright_timeout = nil
+    allow_any_instance_of(Playwright::ElementHandle).to receive(:click).and_wrap_original do |method, **options|
+      playwright_timeout = options[:timeout]
+      method.call(**options)
+    end
+
+    find('#button').click(wait: 0.1)
+
+    expect(playwright_timeout).to eq(100)
+  end
+
+  it 'does not pass Playwright wait options to RackTest' do
+    app = lambda do |environment|
+      body = environment['PATH_INFO'] == '/clicked' ? 'Clicked' : '<a id="link" href="/clicked">Click</a>'
+      [200, { 'Content-Type' => 'text/html' }, [body]]
+    end
+    rack_test_session = Capybara::Session.new(:rack_test, app)
+    rack_test_session.visit('/')
+
+    rack_test_session.find('#link').click(wait: 0.1)
+
+    expect(rack_test_session.current_path).to eq('/clicked')
+  end
+end

--- a/spec/feature/example_spec.rb
+++ b/spec/feature/example_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'Example' do
     search_field.fill_in(with: 'Capybara')
     search_field.send_keys(:enter)
 
-    all('[data-testid="results-list"] h3').each do |li|
+    all('[data-testid="results-list"] h3', allow_reload: true).each do |li|
       puts "#{li.all('a').first.text} by Capybara"
     end
   end
@@ -87,7 +87,7 @@ RSpec.describe 'Example' do
       page.get_by_label('Search or jump to', exact: true).press('Enter')
     end
 
-    all('[data-testid="results-list"] h3').each do |li|
+    all('[data-testid="results-list"] h3', allow_reload: true).each do |li|
       puts "#{li.with_playwright_element_handle { |handle| handle.text_content }} by Playwright"
     end
   end

--- a/spec/feature/stale_element_spec.rb
+++ b/spec/feature/stale_element_spec.rb
@@ -63,6 +63,43 @@ RSpec.describe 'stale element handling' do
     JAVASCRIPT
   end
 
+  def drag_elements_replaced_during_action
+    page.driver.with_playwright_page do |page|
+      page.content = <<~HTML
+        <style>
+          #source, #target { position: absolute; width: 50px; height: 50px; }
+          #source { left: 0; top: 0; }
+          #target { left: 200px; top: 0; }
+        </style>
+        <div id="source"></div>
+        <div id="target"></div>
+        <script>
+          window.mouseupCount = 0;
+          window.targetReplaced = false;
+          document.addEventListener('mousedown', function(event) {
+            if (event.target.id !== 'source' || window.targetReplaced) return;
+
+            window.targetReplaced = true;
+            const target = document.getElementById('target');
+            target.replaceWith(target.cloneNode(true));
+          });
+          document.addEventListener('mouseup', function(event) {
+            window.mouseupCount += 1;
+            document.body.dataset.mouseupTarget = event.target.id;
+          });
+        </script>
+      HTML
+    end
+    source = find('#source')
+    target = find('#target')
+    page.execute_script(<<~JAVASCRIPT)
+      const source = document.getElementById('source');
+      source.replaceWith(source.cloneNode(true));
+    JAVASCRIPT
+
+    [source, target]
+  end
+
   describe 'Element#inspect' do
     it 'works when the element is replaced between find and inspect' do
       el = find('#myid')
@@ -79,20 +116,34 @@ RSpec.describe 'stale element handling' do
     end
   end
 
-  {
-    click: 'click',
-    right_click: 'contextmenu',
-    double_click: 'dblclick',
-  }.each do |action, event_name|
-    it "retries #{action} and waits for the replacement to become actionable" do
-      install_button(event_name)
-      element = find('#myid')
+  it 'retries clicking and waits for the replacement to become actionable' do
+    install_button('click')
+    element = find('#myid')
 
-      replace_with_temporarily_disabled_button
-      element.public_send(action)
+    replace_with_temporarily_disabled_button
+    element.click
 
-      expect(page.evaluate_script('window.actionCount')).to eq(1)
-    end
+    expect(page.evaluate_script('window.actionCount')).to eq(1)
+  end
+
+  it 'retries right-clicking and waits for the replacement to become actionable' do
+    install_button('contextmenu')
+    element = find('#myid')
+
+    replace_with_temporarily_disabled_button
+    element.right_click
+
+    expect(page.evaluate_script('window.actionCount')).to eq(1)
+  end
+
+  it 'retries double-clicking and waits for the replacement to become actionable' do
+    install_button('dblclick')
+    element = find('#myid')
+
+    replace_with_temporarily_disabled_button
+    element.double_click
+
+    expect(page.evaluate_script('window.actionCount')).to eq(1)
   end
 
   it 'retries a centered offset click when the element is replaced during position calculation' do
@@ -140,43 +191,17 @@ RSpec.describe 'stale element handling' do
     expect(element.obscured?).to be false
   end
 
-  it 'reloads both drag endpoints and releases the mouse before retrying' do
-    page.driver.with_playwright_page do |page|
-      page.content = <<~HTML
-        <style>
-          #source, #target { position: absolute; width: 50px; height: 50px; }
-          #source { left: 0; top: 0; }
-          #target { left: 200px; top: 0; }
-        </style>
-        <div id="source"></div>
-        <div id="target"></div>
-        <script>
-          window.mouseupCount = 0;
-          window.targetReplaced = false;
-          document.addEventListener('mousedown', function(event) {
-            if (event.target.id !== 'source' || window.targetReplaced) return;
-
-            window.targetReplaced = true;
-            const target = document.getElementById('target');
-            target.replaceWith(target.cloneNode(true));
-          });
-          document.addEventListener('mouseup', function(event) {
-            window.mouseupCount += 1;
-            document.body.dataset.mouseupTarget = event.target.id;
-          });
-        </script>
-      HTML
-    end
-    source = find('#source')
-    target = find('#target')
-
-    page.execute_script(<<~JAVASCRIPT)
-      const source = document.getElementById('source');
-      source.replaceWith(source.cloneNode(true));
-    JAVASCRIPT
+  it 'reloads both drag endpoints when they are replaced' do
+    source, target = drag_elements_replaced_during_action
     source.drag_to(target)
 
     expect(page.evaluate_script('document.body.dataset.mouseupTarget')).to eq('target')
+  end
+
+  it 'releases the mouse before retrying a stale drag target' do
+    source, target = drag_elements_replaced_during_action
+    source.drag_to(target)
+
     expect(page.evaluate_script('window.mouseupCount')).to eq(2)
   end
 

--- a/spec/feature/stale_element_spec.rb
+++ b/spec/feature/stale_element_spec.rb
@@ -14,10 +14,9 @@ RSpec.describe 'stale element handling' do
     page.evaluate_script(<<~JAVASCRIPT)
       (() => {
         const el = document.getElementById('myid');
-        const newElement = document.createElement('div');
-        newElement.id = 'myid';
+        const newElement = el.cloneNode(true);
         newElement.textContent = 'New Element';
-        document.getElementById('myid').replaceWith(newElement);
+        el.replaceWith(newElement);
       })()
     JAVASCRIPT
   end
@@ -26,12 +25,42 @@ RSpec.describe 'stale element handling' do
     # Hooks into the assert_element_not_stale method to simulate an HTML
     # element being replaced right after the staleness check, but before the block is called.
     original_method = Capybara::Playwright::Node.instance_method(:assert_element_not_stale)
+    rerendered = false
     allow_any_instance_of(Capybara::Playwright::Node).to receive(:assert_element_not_stale) do |instance, &blk|
       original_method.bind(instance).call do
-        rerender_element
+        unless rerendered
+          rerender_element
+          rerendered = true
+        end
         blk.call
       end
     end
+  end
+
+  def install_button(event_name)
+    page.driver.with_playwright_page do |page|
+      page.content = <<~HTML
+        <button id="myid">Old Element</button>
+        <script>
+          window.actionCount = 0;
+          document.addEventListener('#{event_name}', function(event) {
+            if (event.target.id === 'myid') window.actionCount += 1;
+          });
+        </script>
+      HTML
+    end
+  end
+
+  def replace_with_temporarily_disabled_button
+    page.evaluate_script(<<~JAVASCRIPT)
+      (() => {
+        const oldButton = document.getElementById('myid');
+        const newButton = oldButton.cloneNode(true);
+        newButton.disabled = true;
+        oldButton.replaceWith(newButton);
+        setTimeout(() => { newButton.disabled = false }, 100);
+      })()
+    JAVASCRIPT
   end
 
   describe 'Element#inspect' do
@@ -48,6 +77,107 @@ RSpec.describe 'stale element handling' do
       simulate_rerender_immediately_after_enabled_check
       expect(el.inspect).to eq('Obsolete #<Capybara::Node::Element>')
     end
+  end
+
+  {
+    click: 'click',
+    right_click: 'contextmenu',
+    double_click: 'dblclick',
+  }.each do |action, event_name|
+    it "retries #{action} and waits for the replacement to become actionable" do
+      install_button(event_name)
+      element = find('#myid')
+
+      replace_with_temporarily_disabled_button
+      element.public_send(action)
+
+      expect(page.evaluate_script('window.actionCount')).to eq(1)
+    end
+  end
+
+  it 'retries a centered offset click when the element is replaced during position calculation' do
+    install_button('click')
+    element = find('#myid')
+
+    simulate_rerender_immediately_after_enabled_check
+    element.click(x: 0, y: 0)
+
+    expect(page.evaluate_script('window.actionCount')).to eq(1)
+  end
+
+  it 'retries hovering and preserves Playwright actionability waiting' do
+    page.driver.with_playwright_page do |page|
+      page.content = <<~HTML
+        <style>
+          #myid, #overlay { position: absolute; left: 0; top: 0; width: 100px; height: 40px; }
+          #overlay { z-index: 1; }
+        </style>
+        <button id="myid">Old Element</button>
+        <div id="overlay"></div>
+        <script>
+          window.hoverCount = 0;
+          document.addEventListener('mouseover', function(event) {
+            if (event.target.id === 'myid') window.hoverCount += 1;
+          });
+        </script>
+      HTML
+    end
+    element = find('#myid')
+
+    rerender_element
+    page.execute_script("setTimeout(() => { document.getElementById('overlay').remove() }, 100)")
+    element.hover
+
+    expect(page.evaluate_script('window.hoverCount')).to eq(1)
+  end
+
+  it 'retries obscured checks after the element is replaced' do
+    install_button('click')
+    element = find('#myid')
+
+    rerender_element
+
+    expect(element.obscured?).to be false
+  end
+
+  it 'reloads both drag endpoints and releases the mouse before retrying' do
+    page.driver.with_playwright_page do |page|
+      page.content = <<~HTML
+        <style>
+          #source, #target { position: absolute; width: 50px; height: 50px; }
+          #source { left: 0; top: 0; }
+          #target { left: 200px; top: 0; }
+        </style>
+        <div id="source"></div>
+        <div id="target"></div>
+        <script>
+          window.mouseupCount = 0;
+          window.targetReplaced = false;
+          document.addEventListener('mousedown', function(event) {
+            if (event.target.id !== 'source' || window.targetReplaced) return;
+
+            window.targetReplaced = true;
+            const target = document.getElementById('target');
+            target.replaceWith(target.cloneNode(true));
+          });
+          document.addEventListener('mouseup', function(event) {
+            window.mouseupCount += 1;
+            document.body.dataset.mouseupTarget = event.target.id;
+          });
+        </script>
+      HTML
+    end
+    source = find('#source')
+    target = find('#target')
+
+    page.execute_script(<<~JAVASCRIPT)
+      const source = document.getElementById('source');
+      source.replaceWith(source.cloneNode(true));
+    JAVASCRIPT
+    source.drag_to(target)
+
+    expect(page.evaluate_script('document.body.dataset.mouseupTarget')).to eq('target')
+    expect(page.evaluate_script('window.mouseupCount')).to eq(2)
   end
 
   it 'retries filling when the selected input is replaced before typing' do

--- a/spec/feature/stale_element_spec.rb
+++ b/spec/feature/stale_element_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe 'stale element handling' do
   it 'does not treat an attached click target without a bounding box as stale' do
     element = attached_hidden_click_element
 
-    expect { element.click(x: 0, y: 0, wait: 0.5) }
+    expect { element.click(x: 0, y: 0, offset: :center, wait: 0.5) }
       .to raise_error(Capybara::Playwright::Node::MissingBoundingBoxError)
   end
 

--- a/spec/feature/stale_element_spec.rb
+++ b/spec/feature/stale_element_spec.rb
@@ -320,6 +320,38 @@ RSpec.describe 'stale element handling' do
     expect(page.evaluate_script('document.body.dataset.mouseupTarget')).to eq('target')
   end
 
+  it 'drags to an off-screen target when scrolling unmounts the source' do
+    page.driver.with_playwright_page do |page|
+      page.content = <<~HTML
+        <style>
+          body { margin: 0; min-height: 2100px; }
+          #source, #target { position: absolute; width: 50px; height: 50px; }
+          #source { left: 0; top: 0; }
+          #target { left: 0; top: 2000px; }
+        </style>
+        <div id="source"></div>
+        <div id="target"></div>
+        <script>
+          window.addEventListener('scroll', function() {
+            if (window.scrollY <= 100) return;
+
+            const source = document.getElementById('source');
+            if (source) source.remove();
+          });
+          document.addEventListener('mouseup', function(event) {
+            document.body.dataset.mouseupTarget = event.target.id;
+          });
+        </script>
+      HTML
+    end
+    source = find('#source')
+    target = find('#target')
+
+    source.drag_to(target)
+
+    expect(page.evaluate_script('document.body.dataset.mouseupTarget')).to eq('target')
+  end
+
   it 'does not treat an attached drag target without a bounding box as stale' do
     source, target = drag_with_attached_hidden_target
 

--- a/spec/feature/stale_element_spec.rb
+++ b/spec/feature/stale_element_spec.rb
@@ -292,11 +292,41 @@ RSpec.describe 'stale element handling' do
     expect(page.evaluate_script('document.body.dataset.mouseupTarget')).to eq('target')
   end
 
+  it 'waits for a temporarily hidden drag target to become actionable' do
+    page.driver.with_playwright_page do |page|
+      page.content = <<~HTML
+        <style>
+          #source, #target { position: absolute; width: 50px; height: 50px; }
+          #source { left: 0; top: 0; }
+          #target { display: none; left: 200px; top: 0; }
+        </style>
+        <div id="source"></div>
+        <div id="target"></div>
+        <script>
+          document.addEventListener('mouseup', function(event) {
+            document.body.dataset.mouseupTarget = event.target.id;
+          });
+          setTimeout(function() {
+            document.getElementById('target').style.display = 'block';
+          }, 100);
+        </script>
+      HTML
+    end
+    source = find('#source')
+    target = find('#target', visible: :all)
+
+    source.drag_to(target)
+
+    expect(page.evaluate_script('document.body.dataset.mouseupTarget')).to eq('target')
+  end
+
   it 'does not treat an attached drag target without a bounding box as stale' do
     source, target = drag_with_attached_hidden_target
 
-    expect { source.drag_to(target) }
-      .to raise_error(Capybara::Playwright::Node::MissingBoundingBoxError)
+    Capybara.using_wait_time(0.1) do
+      expect { source.drag_to(target) }
+        .to raise_error(Playwright::TimeoutError)
+    end
   end
 
   it 'raises a non-retryable error when a drag target becomes stale after mouse down' do

--- a/spec/feature/stale_element_spec.rb
+++ b/spec/feature/stale_element_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe 'stale element handling' do
     JAVASCRIPT
   end
 
-  def drag_elements_replaced_during_action
+  def drag_elements_replaced_before_action
     page.driver.with_playwright_page do |page|
       page.content = <<~HTML
         <style>
@@ -74,10 +74,43 @@ RSpec.describe 'stale element handling' do
         <div id="source"></div>
         <div id="target"></div>
         <script>
+          document.addEventListener('mouseup', function(event) {
+            document.body.dataset.mouseupTarget = event.target.id;
+          });
+        </script>
+      HTML
+    end
+    source = find('#source')
+    target = find('#target')
+    page.execute_script(<<~JAVASCRIPT)
+      const source = document.getElementById('source');
+      const target = document.getElementById('target');
+      source.replaceWith(source.cloneNode(true));
+      target.replaceWith(target.cloneNode(true));
+    JAVASCRIPT
+
+    [source, target]
+  end
+
+  def drag_elements_replaced_after_mouse_down
+    page.driver.with_playwright_page do |page|
+      page.content = <<~HTML
+        <style>
+          #source, #target { position: absolute; width: 50px; height: 50px; }
+          #source { left: 0; top: 0; }
+          #target { left: 200px; top: 0; }
+        </style>
+        <div id="source"></div>
+        <div id="target"></div>
+        <script>
+          window.mousedownCount = 0;
           window.mouseupCount = 0;
           window.targetReplaced = false;
           document.addEventListener('mousedown', function(event) {
-            if (event.target.id !== 'source' || window.targetReplaced) return;
+            if (event.target.id !== 'source') return;
+
+            window.mousedownCount += 1;
+            if (window.targetReplaced) return;
 
             window.targetReplaced = true;
             const target = document.getElementById('target');
@@ -92,9 +125,53 @@ RSpec.describe 'stale element handling' do
     end
     source = find('#source')
     target = find('#target')
+
+    [source, target]
+  end
+
+  def perform_interrupted_drag(source, target)
+    source.drag_to(target)
+  rescue Capybara::Playwright::Node::DragInterruptedError
+  end
+
+  def attached_hidden_click_element
+    page.driver.with_playwright_page do |page|
+      page.content = <<~HTML
+        <button class="item" id="original" style="display: none">Original</button>
+      HTML
+    end
+    element = find('.item', visible: :all)
     page.execute_script(<<~JAVASCRIPT)
-      const source = document.getElementById('source');
-      source.replaceWith(source.cloneNode(true));
+      const other = document.createElement('button');
+      other.className = 'item';
+      other.id = 'other';
+      other.textContent = 'Other';
+      document.getElementById('original').before(other);
+    JAVASCRIPT
+
+    element
+  end
+
+  def drag_with_attached_hidden_target
+    page.driver.with_playwright_page do |page|
+      page.content = <<~HTML
+        <style>
+          #source, .target { position: absolute; width: 50px; height: 50px; }
+          #source { left: 0; top: 0; }
+          #original { display: none; }
+          #other { left: 200px; top: 0; }
+        </style>
+        <div id="source"></div>
+        <div class="target" id="original"></div>
+      HTML
+    end
+    source = find('#source')
+    target = find('.target', visible: :all)
+    page.execute_script(<<~JAVASCRIPT)
+      const other = document.createElement('div');
+      other.className = 'target';
+      other.id = 'other';
+      document.getElementById('original').before(other);
     JAVASCRIPT
 
     [source, target]
@@ -156,6 +233,23 @@ RSpec.describe 'stale element handling' do
     expect(page.evaluate_script('window.actionCount')).to eq(1)
   end
 
+  it 'does not treat an attached click target without a bounding box as stale' do
+    element = attached_hidden_click_element
+
+    expect { element.click(x: 0, y: 0, wait: 0.5) }
+      .to raise_error(Capybara::Playwright::Node::MissingBoundingBoxError)
+  end
+
+  it 'preserves the stale element error when click retries are disabled' do
+    install_button('click')
+    element = find('#myid')
+
+    rerender_element
+
+    expect { element.click(wait: false) }
+      .to raise_error(Capybara::Playwright::Node::StaleReferenceError)
+  end
+
   it 'retries hovering and preserves Playwright actionability waiting' do
     page.driver.with_playwright_page do |page|
       page.content = <<~HTML
@@ -192,17 +286,38 @@ RSpec.describe 'stale element handling' do
   end
 
   it 'reloads both drag endpoints when they are replaced' do
-    source, target = drag_elements_replaced_during_action
+    source, target = drag_elements_replaced_before_action
     source.drag_to(target)
 
     expect(page.evaluate_script('document.body.dataset.mouseupTarget')).to eq('target')
   end
 
-  it 'releases the mouse before retrying a stale drag target' do
-    source, target = drag_elements_replaced_during_action
-    source.drag_to(target)
+  it 'does not treat an attached drag target without a bounding box as stale' do
+    source, target = drag_with_attached_hidden_target
 
-    expect(page.evaluate_script('window.mouseupCount')).to eq(2)
+    expect { source.drag_to(target) }
+      .to raise_error(Capybara::Playwright::Node::MissingBoundingBoxError)
+  end
+
+  it 'raises a non-retryable error when a drag target becomes stale after mouse down' do
+    source, target = drag_elements_replaced_after_mouse_down
+
+    expect { source.drag_to(target) }
+      .to raise_error(Capybara::Playwright::Node::DragInterruptedError)
+  end
+
+  it 'does not repeat mouse down when a drag target becomes stale after input begins' do
+    source, target = drag_elements_replaced_after_mouse_down
+
+    expect { perform_interrupted_drag(source, target) }
+      .to change { page.evaluate_script('window.mousedownCount') }.by(1)
+  end
+
+  it 'releases the mouse once when a drag target becomes stale after input begins' do
+    source, target = drag_elements_replaced_after_mouse_down
+
+    expect { perform_interrupted_drag(source, target) }
+      .to change { page.evaluate_script('window.mouseupCount') }.by(1)
   end
 
   it 'retries filling when the selected input is replaced before typing' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,7 +46,7 @@ RSpec.configure do |config|
       Host: '127.0.0.1',
       Port: 4567)
 
-    test_server.start_async
+    test_server_thread = test_server.start_async
     test_server.wait_for_ready
     Capybara.app_host = 'http://localhost:4567'
 
@@ -55,8 +55,8 @@ RSpec.configure do |config|
     example.run
     Capybara.default_max_wait_time = previous_wait_time
 
-    test_server.stop_async
-    test_server.wait_for_stopped
+    test_server.stop_async.join
+    test_server_thread.join
   end
 
   test_with_sinatra = Module.new do


### PR DESCRIPTION
## Summary

- preserve Playwright actionability waiting while allowing Capybara to reload and retry replaced element handles
- translate stale errors for click, right-click, double-click, hover, obscured checks, and missing geometry
- reload both drag endpoints and release held mouse and modifier state before retrying
- add focused coverage for reactive replacement before and during actions

Fixes #156

## Test plan

- `CI=1 bundle exec rspec spec/feature/stale_element_spec.rb` — 12 examples, 0 failures
- `CI=1 bundle exec rspec spec/capybara/playwright_spec.rb --example click` — 209 examples, 0 failures, 7 existing pending
- focused hover compatibility examples — 3 examples, 0 failures
- focused drag compatibility examples — 8 supported examples, 0 failures
- focused obscured compatibility examples — 8 examples, 0 failures
- `CI=1 bundle exec rspec spec/feature/allow_label_click_spec.rb` — 7 examples, 0 failures

WebKit and Firefox were not available in the local Playwright browser cache; cross-browser verification is left to the existing GitHub Actions matrix.